### PR TITLE
Fix CODEOWNERS team reference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @gls-ecl/android-team
+*       @bettermile/android-team


### PR DESCRIPTION
Why: automatically assign team for code reviews