### PR TITLE
Extract dependency versions to version catalog

### DIFF
--- a/YamlConverter/build.gradle.kts
+++ b/YamlConverter/build.gradle.kts
@@ -17,10 +17,10 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-core:2.12.7")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.7")
-    implementation("com.google.guava:guava:30.0-jre")
-    implementation("com.github.spullara.mustache.java:compiler:0.9.10")
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.yaml)
+    implementation(libs.google.guava)
+    implementation(libs.mustache)
 
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath(libs.android.build.tools.gradle)
+        classpath(libs.kotlin.gradle)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,31 @@
+[versions]
+android-tools = "7.3.1"
+androidx-activity = "1.6.0"
+androidx-core = "1.9.0"
+androidx-lifecycle = "2.5.1"
+compose-compiler = "1.3.2"
+compose-library = "1.2.1"
+google-guava = "30.0-jre"
+jackson = "2.12.7"
+kotlin = "1.7.20"
+mustache = "0.9.10"
+
+[libraries]
+# gradle classpath plugins
+android-build-tools-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-tools" }
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+# libraries
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
+compose-material = { module = "androidx.compose.material:material", version.ref = "compose-library" }
+compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose-library" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose-library" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-library" }
+google-guava = { module = "com.google.guava:guava", version.ref = "google-guava" }
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+mustache = { module = "com.github.spullara.mustache.java:compiler", version.ref = "mustache" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -34,11 +34,11 @@ repositories {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-core:2.12.7")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.7")
-    implementation("com.github.spullara.mustache.java:compiler:0.9.10")
+    implementation(libs.jackson.core)
+    implementation(libs.jackson.yaml)
+    implementation(libs.mustache)
 
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.kotlin.test.junit)
 }
 
 val sourcesJar by tasks.register<Jar>("sourcesJar") {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.3.2"
+        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
     packagingOptions {
         resources {
@@ -52,13 +52,10 @@ repositories {
 dependencies {
 
     implementation(project(":library"))
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
-    implementation("androidx.activity:activity-compose:1.6.0")
-    val composeVersion = "1.2.1"
-    implementation("androidx.compose.ui:ui:$composeVersion")
-    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
-    implementation("androidx.compose.material:material:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material)
 }


### PR DESCRIPTION
After adding renovate we got quite some dependency update PRs, in different files. So I wanted to align this library with our other repositories and use the version catalog.