### PR TITLE
NO-JIRA: Ignore bot in renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "gitIgnoredAuthors": [
+    "github@gls-ecl.com"
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
Ignore bot in renovate PRs

> By default, Renovate will treat any PR as modified if another Git author has added to the branch. When a PR is considered modified, Renovate won't perform any further commits such as if it's conflicted or needs a version update. If you have other bots which commit on top of Renovate PRs, and don't want Renovate to treat these PRs as modified, then add the other Git author(s) to gitIgnoredAuthors.

Documentation: https://docs.renovatebot.com/configuration-options/#gitignoredauthors