### PR TITLE
SESA-3224: Convert publication to maven central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,4 @@ jobs:
         run: ./gradlew build
 
       - name: Test Publication
-        run: ./gradlew publishAddressFormatterPublicationToMavenLocal
+        run: ./gradlew publishMavenPublicationToMavenLocal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish on GitHub Packages
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:
@@ -21,7 +23,17 @@ jobs:
           distribution: 'temurin'
           java-version: 11
 
+      - name: Set VCS tag
+        id: variables
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
       - name: Publish on GitHub Packages
         run: ./gradlew publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signReleaseEnabled: true
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.PUBLISH_GPG_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.PUBLISH_GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.PUBLISH_GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          VCS_TAG: ${{ steps.variables.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Gradle (Kotlin)
 
 ```kotlin
 dependencies {
-    implementation("com.bettermile:address-formatter-kotlin:0.2.0")
+    implementation("com.bettermile:address-formatter-kotlin:0.3.0")
 }
 ```
 
@@ -28,7 +28,7 @@ Gradle (Groovy)
 
 ```groovy
 dependencies {
-    implementation 'com.bettermile:address-formatter-kotlin:0.2.0'
+    implementation 'com.bettermile:address-formatter-kotlin:0.3.0'
 }
 ```
 
@@ -38,7 +38,7 @@ Maven
 <dependency>
   <groupId>com.bettermile</groupId>
   <artifactId>address-formatter-kotlin</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
 </dependency> 
 ```
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ dokka = "1.9.20"
 jackson = "2.17.2"
 kotlin = "2.0.0"
 kotlinpoet = "1.18.1"
+maven-publish = "0.29.0"
 mustache = "0.9.14"
 
 [libraries]
@@ -18,3 +19,4 @@ mustache = { module = "com.github.spullara.mustache.java:compiler", version.ref 
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/library/src/main/java/com/bettermile/addressformatter/AddressFormatter.kt
+++ b/library/src/main/java/com/bettermile/addressformatter/AddressFormatter.kt
@@ -354,7 +354,7 @@ class AddressFormatter(
             .joinToString(separator = "\n")
     }
 
-    companion object {
+    private companion object {
         private val regexPatternCache = RegexPatternCache()
         private val uppercaseRegex = "[A-Z]".toRegex()
         private val smallDistrictCounties =


### PR DESCRIPTION
* Use `com.vanniktech.maven.publish` plugin to publish (easier configuration then standard `maven-publish` plugin)
* base publishing on git tags
* enable release signing
* add additional pom info
* make `AddressFormatter.Companion` private, because it has no usage in the publication.