### PR TITLE
SESA-3480: Add abbreviation tests

### DIFF
--- a/YamlConverter/build.gradle.kts
+++ b/YamlConverter/build.gradle.kts
@@ -19,9 +19,8 @@ plugins {
     application
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+kotlin {
+    jvmToolchain(11)
 }
 
 application {

--- a/YamlConverter/src/main/java/com/bettermile/addressformatter/yamlconverter/TestCasesTranspiler.kt
+++ b/YamlConverter/src/main/java/com/bettermile/addressformatter/yamlconverter/TestCasesTranspiler.kt
@@ -28,11 +28,11 @@ import com.squareup.kotlinpoet.joinToCode
 object TestCasesTranspiler {
     private val testCaseClass = ClassName("com.bettermile.addressformatter", "TestCase")
 
-    fun yamlToFile(testCases: List<Pair<String, List<ObjectNode>>>): FileSpec {
+    fun yamlToFile(testCases: List<Input>): FileSpec {
         return generatedFileSpec("TestCases") {
             val type = List::class.asClassName().parameterizedBy(testCaseClass)
-            val elements: List<CodeBlock> = testCases.flatMap { (fileName, testCases) ->
-                testCases.map { testCase ->
+            val elements: List<CodeBlock> = testCases.flatMap { input ->
+                input.tests.map { testCase ->
                     val components: List<CodeBlock> = testCase["components"].properties().map { (key, value) ->
                         CodeBlock.of("%S·to·%S", key, value.asText())
                     }
@@ -42,7 +42,8 @@ object TestCasesTranspiler {
                         CodeBlock.of("components·=·mapOf(%L)", components.joinToCode(", ")),
                         CodeBlock.of("expected·=·%S", expected),
                         CodeBlock.of("description·=·%S", description),
-                        CodeBlock.of("fileName·=·%S", fileName),
+                        CodeBlock.of("fileName·=·%S", input.fileName),
+                        CodeBlock.of("abbreviate·=·%L", input.abbreviate),
                     )
                     multilineFunctionCall(testCaseClass, properties)
                 }
@@ -54,4 +55,10 @@ object TestCasesTranspiler {
             )
         }
     }
+
+    data class Input(
+        val fileName: String,
+        val tests: List<ObjectNode>,
+        val abbreviate: Boolean,
+    )
 }

--- a/library/src/main/java/com/bettermile/addressformatter/AddressFormatter.kt
+++ b/library/src/main/java/com/bettermile/addressformatter/AddressFormatter.kt
@@ -239,7 +239,7 @@ class AddressFormatter(
                 abbreviation.forEach abbreviationForEach@{ (component, abbrs) ->
                     var value = components[component] ?: return@abbreviationForEach
                     abbrs.forEach { (src, dest) ->
-                        val regex = regexPatternCache["\\b$src\\b"]
+                        val regex = regexPatternCache["(?<=^|\\s)$src(?=\\s|\$)"]
                         value = regex.replace(value, dest)
                     }
                     components[component] = value

--- a/library/src/test/java/com/bettermile/addressformatter/AddressFormatterTest.kt
+++ b/library/src/test/java/com/bettermile/addressformatter/AddressFormatterTest.kt
@@ -28,23 +28,27 @@ import org.junit.runners.Parameterized
 @RunWith(Enclosed::class)
 class AddressFormatterTest {
     @RunWith(Parameterized::class)
-    class ParameterizedAddressFormatterTest(testCase: TestCase, @Suppress("UNUSED_PARAMETER") testName: String?) {
-        private val components: Map<String, String> = testCase.components
-        private val address: String = testCase.expected
+    class ParameterizedAddressFormatterTest(
+        private val testCase: TestCase,
+        @Suppress("UNUSED_PARAMETER") testName: String?,
+    ) {
 
         @Test
         fun worksWithAddressesWorldwide() {
-            val formatted = formatter.format(components)
-            Assert.assertEquals(address, formatted)
+            val formatter = if (testCase.abbreviate) abbreviateFormatter else formatter
+            val formatted = formatter.format(testCase.components)
+            Assert.assertEquals(testCase.expected, formatted)
         }
 
         companion object {
             lateinit var formatter: AddressFormatter
+            lateinit var abbreviateFormatter: AddressFormatter
 
             @BeforeClass
             @JvmStatic
             fun setup() {
                 formatter = AddressFormatter(abbreviate = false, appendCountry = false)
+                abbreviateFormatter = AddressFormatter(abbreviate = true, appendCountry = false)
             }
 
             @JvmStatic

--- a/library/src/test/java/com/bettermile/addressformatter/TestCase.kt
+++ b/library/src/test/java/com/bettermile/addressformatter/TestCase.kt
@@ -21,4 +21,5 @@ data class TestCase(
     val expected: String,
     val description: String,
     val fileName: String,
+    val abbreviate: Boolean,
 )

--- a/library/src/test/java/com/bettermile/addressformatter/generated/TestCases.kt
+++ b/library/src/test/java/com/bettermile/addressformatter/generated/TestCases.kt
@@ -20,6 +20,48 @@ import kotlin.collections.List
 
 public val testCases: List<TestCase> = listOf(
       TestCase(
+        components = mapOf("city" to "Berlin", "country" to "Deutschland", "country_code" to "de", "road" to "Platz der Republik", "state" to "Berlin"),
+        expected = """
+        |Pl der Republik
+        |Berlin
+        |Deutschland
+        |""".trimMargin(),
+        description = "Platz der Republik",
+        fileName = "abbreviations - de",
+        abbreviate = true,
+      ),
+      TestCase(
+        components = mapOf("city" to "München", "country" to "Deutschland", "country_code" to "de", "house_number" to "6", "postcode" to "81829", "road" to "Willy-Brandt-Platz", "state" to "Bayern"),
+        expected = """
+        |Willy-Brandt-Platz 6
+        |81829 München
+        |Deutschland
+        |""".trimMargin(),
+        description = "willy-Brandt-Platz",
+        fileName = "abbreviations - de",
+        abbreviate = true,
+      ),
+      TestCase(
+        components = mapOf("city" to "Pueblo", "country_code" to "us", "house_number" to "123", "postcode" to "81001", "road" to "Augusta Lane", "state" to "Colorado", "state_code" to "CO"),
+        expected = """
+        |123 Augusta Ln
+        |Pueblo, CO 81001
+        |""".trimMargin(),
+        description = "Augusta Lane",
+        fileName = "abbreviations - en",
+        abbreviate = true,
+      ),
+      TestCase(
+        components = mapOf("city" to "Haguenau", "country_code" to "fr", "postcode" to "67500", "road" to "Rue de Voituriers"),
+        expected = """
+        |R de Voituriers
+        |67500 Haguenau
+        |""".trimMargin(),
+        description = "Rue de Voituriers",
+        fileName = "abbreviations - fr",
+        abbreviate = true,
+      ),
+      TestCase(
         components = mapOf("country" to "Andorra", "country_code" to "ad", "county" to "Andorra la Vella", "house_number" to "88", "neighbourhood" to "Centre històric", "postcode" to "AD500", "road" to "Avinguda Meritxell", "town" to "Andorra la Vella"),
         expected = """
         |88 Avinguda Meritxell
@@ -28,6 +70,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Andorra la Vella, 42.50830,1.53014",
         fileName = "countries - ad",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Abu Dhabi", "country" to "United Arab Emirates", "country_code" to "ae", "hotel" to "L'Arabia hotel", "postcode" to "277", "road" to "28th Street", "state" to "Abu Dhabi", "suburb" to "Police Officers City"),
@@ -40,6 +83,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "L'Arabia Hotel, 24.37253,54.53801",
         fileName = "countries - ae",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "أبو ظبي", "country" to "الإمارات العربية المتحدة", "country_code" to "ae", "hotel" to "L'Arabia hotel", "postcode" to "277", "road" to "28th Street", "state" to "أبو ظبي", "suburb" to "Police Officers City"),
@@ -52,6 +96,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "L'Arabia Hotel, language=ar, 24.37253,54.53801",
         fileName = "countries - ae",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Abu Dhabi", "country" to "United Arab Emirates", "country_code" to "ae", "postcode" to "277", "restaurant" to "Pizza Hut", "road" to "8th Street", "state" to "Abu Dhabi", "suburb" to "Police Officers City"),
@@ -64,6 +109,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pizza hut, 24.37289,54.51820",
         fileName = "countries - ae",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dubai", "country" to "United Arab Emirates", "country_code" to "ae", "hospital" to "Thumbay Hospital", "postcode" to "47602", "residential" to "Al Qusais 1", "road" to "Street 4", "state" to "Dubai", "suburb" to "Al Qusais 1"),
@@ -76,6 +122,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Thumbay Hospital, 25.28130/55.36503",
         fileName = "countries - ae",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United Arab Emirates", "country_code" to "ae", "postcode" to "0448", "state" to "Dubai", "suburb" to "International Media Production Zone"),
@@ -86,6 +133,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "International Media Production Zone, 25.0299178/55.1872123",
         fileName = "countries - ae",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Kandahar Institute of Health Sciences", "city" to "Kandahar", "country" to "Afghanistan", "country_code" to "af", "road" to "Kandahar-Herat Highway", "state" to "Kandahar"),
@@ -97,6 +145,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Government building in Kandahar, 31.6110,65.6963",
         fileName = "countries - af",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Scotiabank", "country" to "Antigua and Barbuda", "country_code" to "ag", "postcode" to "Anu", "road" to "High Street", "town" to "St. John's"),
@@ -108,6 +157,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in St. John's, 17.12150,-61.84405",
         fileName = "countries - ag",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Department Of Lands And Surveys", "country" to "Anguilla", "country_code" to "ai", "postcode" to "AI-2640", "road" to "The Valley Road", "town" to "The Valley"),
@@ -119,6 +169,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "building in The Valley, 18.21032,-63.05322",
         fileName = "countries - ai",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Raiffeisen Bank", "city" to "Tiranë", "country" to "Albania", "country_code" to "al", "county" to "Tiranë", "postcode" to "1001", "road" to "Papa Gjon Pali II"),
@@ -130,6 +181,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Tiranë, 41.32036,19.82343",
         fileName = "countries - al",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Tiranë", "country" to "Albania", "country_code" to "al", "county" to "Tirana County", "kindergarten" to "Kopështi nr. 18", "municipality" to "Tirana Municipality", "road" to "Rruga Dalip Zavalani", "state" to "Central Albania", "suburb" to "Njësia Bashkiake Nr. 2"),
@@ -141,6 +193,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Kindergarten in Tiranë, 41.32462,19.83047",
         fileName = "countries - al",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Yerevan", "country" to "Armenia", "country_code" to "am", "house_number" to "8", "postcode" to "0010", "road" to "Abovyan street"),
@@ -152,6 +205,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Yerevan, 40.18045,44.51534",
         fileName = "countries - am",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Embassy of the Federal Republic of Germany", "city" to "Luanda", "country" to "Angola", "country_code" to "ao", "house_number" to "120", "neighbourhood" to "Mutamba", "road" to "Avenida 4 de Fevereiro", "state" to "Luanda"),
@@ -163,6 +217,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Luanda, -8.81044,13.23588",
         fileName = "countries - ao",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Oil Separator Building", "continent" to "Antarctica", "country" to "Antarctica", "country_code" to "aq", "house_number" to "72", "road" to "McMurdo Roads", "town" to "McMurdo Station"),
@@ -173,6 +228,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building at McMurdo Station, -77.8460,166.7359",
         fileName = "countries - aq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Autonomous City of Buenos Aires", "city_district" to "Retiro", "country" to "Argentina", "country_code" to "ar", "house" to "CAI", "house_number" to "1250", "postcode" to "C1010AAZ", "road" to "Cerrito", "state" to "Autonomous City of Buenos Aires", "suburb" to "Retiro"),
@@ -185,6 +241,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "SotM 2014 venue -34.59358185, -58.38328315",
         fileName = "countries - ar",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Executive Office Building (American Samoa Government)", "country" to "American Samoa", "country_code" to "as", "county" to "Eastern District", "municipality" to "Maʻopūtasi County", "postcode" to "96799", "road" to "Route 118", "village" to "Utulei"),
@@ -197,6 +254,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Pago Pago, -14.28181,-170.68354",
         fileName = "countries - as",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Salzburg", "country" to "Austria", "country_code" to "AT", "county" to "Bezirk Salzburg", "house_number" to "5", "postcode" to "5020", "road" to "Stauffenstraße", "state" to "Salzburg (state)", "suburb" to "Elisabeth-Vorstadt"),
@@ -207,6 +265,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Salzbug street address",
         fileName = "countries - at",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Melbourne", "country" to "Australia", "country_code" to "AU", "county" to "City of Melbourne", "courthouse" to "Melbourne Magistrates' Court", "house_number" to "223", "postcode" to "3000", "road" to "William Street", "state" to "Victoria", "suburb" to "Melbourne"),
@@ -218,6 +277,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Melbourne Magistrates' Court, -37.8134921, 144.956787658113",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Australia", "country_code" to "au", "county" to "City of Moreland", "postcode" to "3039", "region" to "Greater Melbourne", "road" to "Rainer Street", "state" to "Victoria", "suburb" to "Pascoe Vale South"),
@@ -228,6 +288,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Road in suburb, -37.7319, 144.9381",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sydney", "country" to "Australia", "country_code" to "au", "county" to "Georges River Council", "postcode" to "2219", "pub" to "St George Motor Boat Club", "road" to "Vista Street", "state" to "New South Wales", "state_code" to "NSW", "suburb" to "Sans Souci"),
@@ -239,6 +300,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "suburb over town Sans Souci, -34.000,151.124",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sydney", "country" to "Australia", "country_code" to "au", "county" to "Canterbury-Bankstown Council", "postcode" to "2193", "road" to "Fifth Street", "state" to "New South Wales", "state_code" to "NSW", "suburb" to "Ashbury"),
@@ -249,6 +311,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "suburb over town Ashbury, -33.9,151.1229",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "LASCELLES", "country" to "Australia", "country_code" to "au", "postcode" to "3487", "state" to "VICTORIA"),
@@ -258,6 +321,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "postcode and town",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Lascelles", "country" to "Australia", "country_code" to "au", "municipality" to "Shire of Yarriambiack", "postcode" to "3487", "state" to "VICTORIA"),
@@ -267,6 +331,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "postcode and city_district",
         fileName = "countries - au",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("name" to "Parliament of Aruba", "country" to "Aruba", "country_code" to "aw", "house_number" to "LSB 70", "road" to "L.G. Smith Boulevard", "town" to "Oranjestad"),
@@ -278,6 +343,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Parliament in Oranjestad, 12.51781,-70.03646",
         fileName = "countries - aw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Åland Islands", "country_code" to "ax", "county" to "Åland Islands", "post_box" to "Posten Åland", "postcode" to "22101", "road" to "Nygatan", "state" to "Åland", "state_district" to "Regional State Agency Åland", "suburb" to "Johannebo", "town" to "Mariehamn"),
@@ -289,6 +355,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Mariehamn",
         fileName = "countries - ax",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bank Avrasiya", "city" to "Baku", "country" to "Azerbaijan", "country_code" to "az", "house_number" to "70", "path" to "Nizami küç.", "postcode" to "AZ1014", "state" to "Bakı İnzibati Ərazisi", "suburb" to "Montin"),
@@ -300,6 +367,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Baku, 40.37381,49.84436",
         fileName = "countries - az",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sarajevo", "country" to "Bosnia and Herzegovina", "country_code" to "ba", "county" to "New Sarajevo municipality", "house_number" to "88", "post_office" to "BH Posta", "postcode" to "71000", "road" to "Zmaja od Bosne", "state" to "Entity Federation of Bosnia and Herzegovina", "state_district" to "Sarajevo Canton", "suburb" to "Grbavica"),
@@ -311,6 +379,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Sarajevo, 43.85229,18.38142",
         fileName = "countries - ba",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Bridgetown", "country" to "Barbados", "country_code" to "bb", "county" to "Saint Michael", "neighbourhood" to "New Orleans", "post_office" to "General Post Office", "postcode" to "BB11093", "road" to "Cheapside Road"),
@@ -322,6 +391,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post Office in Bridgetown, 13.09821,-59.62049",
         fileName = "countries - bb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Janata Bank", "city" to "Dhaka", "country" to "Bangladesh", "country_code" to "bd", "postcode" to "1205", "road" to "Shahid Minar Rd", "state" to "Dhaka Division", "suburb" to "Siddikbazar"),
@@ -334,6 +404,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Dhaka, 23.73210,90.39546",
         fileName = "countries - bd",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Antwerp", "city_district" to "Antwerpen", "country" to "Belgium", "country_code" to "be", "county" to "Antwerp", "house_number" to "63", "neighbourhood" to "Sint-Andries", "postcode" to "2000", "restaurant" to "Meat & Eat", "road" to "Vrijheidstraat", "state" to "Flanders"),
@@ -345,6 +416,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Antwerp, 51.21038,4.39812",
         fileName = "countries - be",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "België", "country_code" to "be", "county" to "Huy", "hamlet" to "Clermont-sous-Huy", "house_number" to "187", "municipality" to "Engis", "postcode" to "4480", "region" to "Wallonia", "road" to "Chaussée de Liège", "state" to "Liège"),
@@ -355,6 +427,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "prefer municipality over hamlet, 50.5689247, 5.3918483",
         fileName = "countries - be",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Belgium", "country_code" to "be", "county" to "Halle-Vilvoorde", "municipality" to "Roosdaal", "postcode" to "1760", "region" to "Flanders", "road" to "Kerkveldstraat", "state" to "Flemish Brabant", "village" to "Strijtem"),
@@ -365,6 +438,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "prefer village over municipality 50.84201, 4.11871",
         fileName = "countries - be",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Perwez", "country" to "Belgium", "country_code" to "be", "county" to "Nivelles", "house_number" to "67", "postcode" to "1360", "region" to "Wallonia", "road" to "Rue Salmon", "state" to "Walloon Brabant", "village" to "Perwez"),
@@ -375,6 +449,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "50.62084,4.82240",
         fileName = "countries - be",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Ecobank", "city" to "Ouagadougou", "country" to "Burkina Faso", "country_code" to "bf", "postcode" to "13", "region" to "Centre", "residential" to "Ouagadougou", "road" to "Avenue Nelson Mandela", "state_district" to "Kadiogo", "suburb" to "Bilbalogho"),
@@ -386,6 +461,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Ouagadougou, 12.36884,-1.52794",
         fileName = "countries - bf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Burkina Faso", "country_code" to "bf", "department" to "Tiéfora", "province" to "Comoé", "road" to "unnamed road", "village" to "Bondorola"),
@@ -398,6 +474,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village, Bank in Ouagadougou, 10.5450,-4.5787",
         fileName = "countries - bf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sofia", "country" to "Bulgaria", "country_code" to "BG", "county" to "Sofia-City Region", "road" to "Georgi Sava Rakovski St.", "state" to "RJ", "state_district" to "Região Metropolitana do Rio de Janeiro", "suburb" to "Centre", "postcode" to "1000", "university" to "Krastyo Sarafov National Academy for Theatre and Film Arts"),
@@ -410,6 +487,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "university in Sofia",
         fileName = "countries - bg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Bahrain", "country_code" to "bh", "postcode" to "814", "road" to "Al-Doha Avenue", "state" to "Central Governorate", "supermarket" to "Ramaz", "town" to "Isa Town"),
@@ -421,6 +499,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 26.16969,50.55565",
         fileName = "countries - bh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "البحرين", "country_code" to "bh", "postcode" to "814", "road" to "Al-Doha Avenue", "state" to "المحافظة الوسطى", "supermarket" to "Ramaz", "town" to "مدينة عيسى‎"),
@@ -432,6 +511,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, language=ar, 26.16969,50.55565",
         fileName = "countries - bh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Manama", "country" to "Bahrain", "country_code" to "bh", "hairdresser" to "Kerala Saloon", "postcode" to "301", "road" to "2115,", "state" to "Capital Governorate", "suburb" to "Gudaibiya"),
@@ -443,6 +523,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hair Saloon, 26.22820,50.59449",
         fileName = "countries - bh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Manama", "country" to "Bahrain", "country_code" to "bh", "doctors" to "Al Hoora Health Centre", "postcode" to "317", "road" to "1910,", "state" to "Capital Governorate", "suburb" to "Al Hoora"),
@@ -454,6 +535,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Health Centre, 26.23556,50.59452",
         fileName = "countries - bh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Bonauto s.a.", "city" to "Bujumbura", "country" to "Burundi", "country_code" to "bi", "house_number" to "17", "postcode" to "2730", "road" to "Avenue du Commerce", "state" to "Bujumbura Mairie", "suburb" to "Building Bata"),
@@ -465,6 +547,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Office in Bujumbura, -3.38341,29.36166",
         fileName = "countries - bi",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Benin", "country_code" to "bj", "county" to "12e Arrondissement", "house_number" to "504", "road" to "Rue 12.168", "state" to "Littoral", "suburb" to "Cadjehoun"),
@@ -475,6 +558,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house in Cotonou",
         fileName = "countries - bj",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Saint Barthélemy", "country_code" to "bl", "house_number" to "15", "neighbourhood" to "La Pointe", "postcode" to "97133", "road" to "Rue de Pére Irénée de Bruyn", "state" to "Saint Barthélemy", "town" to "Gustavia"),
@@ -485,6 +569,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Gustavia, 17.89548,-62.85177",
         fileName = "countries - bl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Bermuda", "country_code" to "bm", "county" to "Devonshire", "house_number" to "65", "post_office" to "Flatt's Post Office", "postcode" to "FL 04", "road" to "Middle Road"),
@@ -496,6 +581,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Flatt's, 32.31976,-64.73605",
         fileName = "countries - bm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Gadong Centrepoint", "city" to "Bandar Seri Begawan", "country" to "Brunei", "country_code" to "bn", "county" to "Brunei-Muara", "postcode" to "BE4119", "road" to "Simpang 137"),
@@ -508,6 +594,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Bandar Seri Begawan, 4.90720,114.91566",
         fileName = "countries - bn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Banco Los Andes Pro Credite", "city" to "Municipio Nuestra Senora de La Paz", "country" to "Bolivia", "country_code" to "bo", "county" to "Provincia Murillo", "postcode" to "8686", "road" to "José María Achá", "state" to "La Paz Departament", "suburb" to "Gran Poder"),
@@ -519,6 +606,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in La Paz, -16.49607,-68.14860",
         fileName = "countries - bo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Bonaire", "country" to "Bonaire", "country_code" to "bq", "road" to "Kaya Libertador Simon Bolivar", "school" to "Parokia San Bernardo", "state" to "Caribbean Netherlands", "suburb" to "Sabana"),
@@ -530,6 +618,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "school in Kralendijk, 12.15286,-68.27238",
         fileName = "countries - bq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Rio de Janeiro", "country" to "Brazil", "country_code" to "BR", "county" to "Rio de Janeiro", "road" to "Avenida Maracanã", "state" to "RJ", "state_district" to "Região Metropolitana do Rio de Janeiro", "suburb" to "Maracanã"),
@@ -541,6 +630,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Rio",
         fileName = "countries - br",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Belo Horizonte", "city_district" to "Regional Centro-Sul", "country" to "Brazil", "country_code" to "br", "county" to "Microrregião Belo Horizonte", "neighbourhood" to "Centro", "postcode" to "30170011", "road" to "Rua Rio de Janiero", "state" to "Minas Gerais", "state_district" to "Mesorregião Metropolitana de Belo Horizonte", "suburb" to "Centro"),
@@ -553,6 +643,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "format postcode correctly",
         fileName = "countries - br",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Rio de Janeiro", "city_district" to "Zona Central do Rio de Janeiro", "continent" to "South America", "country" to "Brazil", "country_code" to "br", "county" to "Região Geográfica Imediata do Rio de Janeiro", "house" to "Condomínio Condomínio René Magritte", "house_number" to "68", "postcode" to "22221-000", "road" to "Rua Silveira Martins", "state" to "Rio de Janeiro", "state_code" to "RJ", "state_district" to "Região Geográfica Intermediária do Rio de Janeiro", "suburb" to "Catete"),
@@ -566,6 +657,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "BR housenumber -22.92540,-43.17540",
         fileName = "countries - br",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Brazil", "country_code" to "br", "municipality" to "Região Geográfica Imediata de Picos", "postcode" to "64675-000", "region" to "Northeast Region", "state" to "Piauí", "state_code" to "PI", "state_district" to "Região Geográfica Intermediária de Picos", "village" to "Alegrete do Piauí"),
@@ -577,6 +669,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village",
         fileName = "countries - br",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nassau", "country" to "The Bahamas", "country_code" to "bs", "county" to "New Providence", "courthouse" to "Supreme Court", "road" to "Bank Lane"),
@@ -589,6 +682,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Court in Nassau, 25.07705,-77.34052",
         fileName = "countries - bs",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bhutan National Bank", "city" to "Thimphu", "country" to "Bhutan", "country_code" to "bt", "postcode" to "810", "road" to "Chang Lam", "state" to "Thimphu District"),
@@ -600,6 +694,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "National Bank in Thimphu, 27.47370,89.63880",
         fileName = "countries - bt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Bouvet Island", "country_code" to "bv"),
@@ -608,6 +703,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Lykketoppen, -54.4362/3.3138",
         fileName = "countries - bv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bank Gaborone", "city" to "Gaborone", "country" to "Botswana", "country_code" to "bw", "road" to "Queens Road", "state" to "South-East District"),
@@ -619,6 +715,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Gaborone: -24.65739,25.91755",
         fileName = "countries - bw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Minsk", "city_district" to "Ленинский район", "country" to "Belarus", "country_code" to "BY", "house_number" to "20", "museum" to "Национальный художественный музей", "postcode" to "220030", "road" to "улица Ленина"),
@@ -630,6 +727,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "National Art Museum in Minsk",
         fileName = "countries - by",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Belmopan", "country" to "Belize", "country_code" to "bz", "county" to "Cayo District", "road" to "Nim Li Punit Street", "state" to "Cayo", "supermarket" to "Fransico Supermarket"),
@@ -641,6 +739,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket in Belmopan, 17.2547,-88.7645",
         fileName = "countries - bz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Brampton", "country" to "Canada", "country_code" to "ca", "house_number" to "251", "postcode" to "L6Y 1Z4", "road" to "McMurchy Avenue South", "school" to "Brampton Centennial Secondary School", "state" to "Ontario", "suburb" to "Ridgehill"),
@@ -652,6 +751,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Brampton Centennial Secondary School",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Toronto", "country" to "Canada", "country_code" to "ca", "postcode" to "M6K1V2", "state" to "Ontario", "suburb" to "Parkdale"),
@@ -662,6 +762,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "postcode and suburb",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "country" to "Canada", "country_code" to "ca", "county" to "Middlesex County", "state" to "Ontario", "state_code" to "ON"),
@@ -671,6 +772,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "city, state",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Canada", "country_code" to "ca", "county" to "London", "house_number" to "6", "neighbourhood" to "Lockwood Park", "postcode" to "N6C 2W9", "road" to "Cowan Avenue", "state" to "Ontario", "state_code" to "ON", "state_district" to "Southwestern Ontario"),
@@ -681,6 +783,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "London treated as county - 42.95608,-81.23792",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Brampton", "country" to "Canada", "country_code" to "ca", "postcode" to "L6Y 1Z4", "road" to "McMurchy Avenue South", "school" to "Brampton Centennial Secondary School", "state" to "Ontario", "suburb" to "Ridgehill"),
@@ -692,6 +795,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no housenumber",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Canada", "country_code" to "ca", "county" to "Springfield", "state" to "Manitoba"),
@@ -701,6 +805,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "just county",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Canada", "country_code" to "ca", "county" to "Halton Region", "house_number" to "7931", "locality" to "Halton Hills", "municipality" to "Halton Hills", "postcode" to "L5N 8P7", "road" to "Tenth Line", "state" to "Ontario", "state_district" to "Golden Horseshoe"),
@@ -711,6 +816,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "locality",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Canada", "country_code" to "ca", "house_number" to "12345", "locality" to "St-Hyancinth", "postcode" to "J2T 3T5", "road" to "Av Demars"),
@@ -721,6 +827,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "postformat_replace applied to abbreviated street type",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Canada", "country_code" to "ca", "region" to "Greater Edmonton", "state" to "Alberta", "state_code" to "AB"),
@@ -730,6 +837,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Greater Edmonton, Alberta, Canada",
         fileName = "countries - ca",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Cocos (Keeling) Islands", "country_code" to "cc", "pub" to "Club", "state" to "Cocos (Keeling) Islands", "village" to "West Island"),
@@ -741,6 +849,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pub on West Island, -12.18832,96.82935",
         fileName = "countries - cc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Embassy of the Federal Republic of Germany", "country" to "Congo-Kinshasa", "country_code" to "cd", "house_number" to "82", "postcode" to "243", "road" to "Avenue du Roi Baudouin", "state" to "Kinshasa", "suburb" to "Royal", "town" to "Gombe"),
@@ -752,6 +861,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Kinshasa",
         fileName = "countries - cd",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Ecobank", "city" to "Bangui", "country" to "Central African Republic", "country_code" to "cf", "road" to "Rue de Navarre", "state" to "Ombella M\\'Poko"),
@@ -763,6 +873,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Bangui, 4.36223,18.58393",
         fileName = "countries - cf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("embassy" to "South Africa (Embassy)", "city" to "Brazzaville", "country" to "Congo-Brazzaville", "country_code" to "cg", "neighbourhood" to "Plateau des 15 ans", "road" to "rue de Maya-maya", "state" to "Brazzaville", "suburb" to "Poto-Poto"),
@@ -774,6 +885,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Brazzaville, -4.26708,15.27797",
         fileName = "countries - cg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Zurich", "country" to "Switzerland", "country_code" to "ch", "county" to "Bezirk Zürich", "house_number" to "2", "pedestrian" to "Häringstrasse", "postcode" to "8001", "state" to "Zurich", "suburb" to "Altstadt"),
@@ -784,6 +896,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Zurich, 47.37476,8.54393",
         fileName = "countries - ch",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Treichville", "country" to "Côte d'Ivoire", "country_code" to "ci", "neighbourhood" to "Zone Industriele de Treichville", "post_office" to "La Poste", "postcode" to "00225", "road" to "Boulevard de Marseille", "state" to "Abidjan", "suburb" to "Zone 2b"),
@@ -795,6 +908,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "post office in Abidjan",
         fileName = "countries - ci",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Te-Au-O-Tonga", "country" to "Cook Islands", "country_code" to "ck", "hospital" to "Old Hospital", "road" to "Ara Tapu"),
@@ -806,6 +920,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hospital in north of Rarotonga, -21.2042,-159.7654",
         fileName = "countries - ck",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Providencia", "country" to "Chile", "country_code" to "cl", "county" to "Provincia de Santiago", "house_number" to "920", "neighbourhood" to "Unidad Vecinal Providencia", "postcode" to "7500000", "region" to "Región Metropolitana de Santiago", "road" to "Avenida Ricardo Lyon", "state" to "XIII Región Metropolitana de Santiago", "suburb" to "Providencia"),
@@ -817,6 +932,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "-33.42983,-70.60620",
         fileName = "countries - cl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "ONUDI", "city" to "Yaoundé III", "country" to "Cameroon", "country_code" to "cm", "county" to "CUY", "postcode" to "11852", "road" to "rue 3.025", "state" to "Centre", "suburb" to "Centre Administratif"),
@@ -828,6 +944,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "UN building in Yaoundé, 3.85890,11.51580",
         fileName = "countries - cm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "万向大厦", "country" to "China", "country_code" to "cn", "county" to "Pudong New District", "house_number" to "99号", "neighbourhood" to "Lijuazui", "postcode" to "200120", "road" to "West Lujiazui Road", "state" to "Shanghai"),
@@ -841,6 +958,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Shanghai, 31.23980,121.49316",
         fileName = "countries - cn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "China", "country_code" to "cn", "region" to "Macau"),
@@ -850,6 +968,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Macau",
         fileName = "countries - cn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nyingchi", "country" to "China", "country_code" to "cn", "district" to "Bayi District", "postcode" to "860000", "region" to "Nyingchi Prefecture", "state" to "Tibet", "town" to "Bayi"),
@@ -860,6 +979,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "null",
         fileName = "countries - cn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "33", "road" to "Avenida de los Cerros (Circunvalar)", "city" to "Bogota", "neighbourhood" to "Mariscal Sucre", "country" to "Colombia", "country_code" to "CO", "postcode" to "110231", "state" to "Bogota", "suburb" to "Chapinero"),
@@ -871,6 +991,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "4.63194, -74.06064",
         fileName = "countries - co",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Limón", "country" to "Costa Rica", "country_code" to "cr", "courthouse" to "Tribunales de Justicia", "neighbourhood" to "Barrio Hospital", "postcode" to "70101", "road" to "Calle 2 - Romualdo Segura", "state" to "Limón"),
@@ -882,6 +1003,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Court in Limón, 9.99403,-83.02745",
         fileName = "countries - cr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Embajada de Hungría", "city" to "Havana", "country" to "Cuba", "country_code" to "cu", "county" to "Plaza de la Revolución", "neighbourhood" to "Barrio El Fanguito", "postcode" to "10400", "road" to "Calle 19", "state" to "Havana", "suburb" to "El Vedado"),
@@ -893,6 +1015,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Havana, 23.13763,-82.38976",
         fileName = "countries - cu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Cuba", "country_code" to "cu", "county" to "Centro Habana", "house_number" to "209", "neighbourhood" to "Colón", "road" to "Perseverancia", "state" to "Havana"),
@@ -903,6 +1026,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "address in Havana / no city, 23.13895,-82.36652",
         fileName = "countries - cu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Banco de Cabo Verde", "city" to "Praia", "country" to "Cape Verde", "country_code" to "cv", "county" to "Praia", "neighbourhood" to "Bela Vista", "postcode" to "7600", "road" to "Avenida Amilcar Cabral", "suburb" to "Várzea"),
@@ -914,6 +1038,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Praia, 14.91887,-23.50912",
         fileName = "countries - cv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Curaçao", "country_code" to "cw", "house_number" to "14", "neighbourhood" to "Colon", "postcode" to "0000NA", "road" to "Jan Erasmusstraat", "state" to "Curaçao", "suburb" to "Seru Domi", "town" to "Willemstad"),
@@ -924,6 +1049,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Willemstad, 12.11148,-68.94561",
         fileName = "countries - cw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Christmas Island", "country_code" to "cx", "neighbourhood" to "The Settlement", "postcode" to "6798", "road" to "Gaze Road", "state" to "Christmas Island", "supermarket" to "Christmas Island Supermarket"),
@@ -935,6 +1061,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket on Christmas Island, -10.4230,105.6729",
         fileName = "countries - cx",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bank of Cyprus", "city" to "Limassol", "country" to "Cyprus", "country_code" to "cy", "county" to "Limassol", "pedestrian" to "Agiou Andreou", "postcode" to "3042", "state" to "Cyprus", "suburb" to "Mesa Geitonia"),
@@ -946,6 +1073,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Limassol, 34.67398,33.04388",
         fileName = "countries - cy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Plzeň", "country" to "Czech Republic", "country_code" to "cz", "county" to "okres Plzeň-město", "house_number" to "343/10", "neighbourhood" to "Bory", "postcode" to "30100", "road" to "Resslova", "state" to "Jihozápad", "suburb" to "Plzeň"),
@@ -956,6 +1084,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pilsen street address 49.74258,13.37732",
         fileName = "countries - cz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Berlin", "country" to "Germany", "country_code" to "DE", "state" to "Berlin"),
@@ -965,6 +1094,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no repetition",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Berlin", "city_district" to "Mitte", "country" to "Germany", "country_code" to "de", "state" to "Berlin", "suburb" to "Moabit"),
@@ -975,6 +1105,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Moabit!",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Alt-Berlin", "city_district" to "Mitte", "country" to "Germany", "country_code" to "de", "house_number" to "7", "neighbourhood" to "Scheunenviertel", "pedestrian" to "Gontardstraße", "postcode" to "10178", "state" to "Berlin", "suburb" to "Mitte"),
@@ -985,6 +1116,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Alt-berlin",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Alt-Berlin", "city_district" to "Mitte", "country" to "Germany", "country_code" to "de", "housenumber" to "7", "neighbourhood" to "Scheunenviertel", "pedestrian" to "Gontardstraße", "postcode" to "10178", "state" to "Berlin", "suburb" to "Mitte"),
@@ -995,6 +1127,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "housenumber not house_number",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Germany", "country_code" to "de", "county" to "Cologne", "state" to "North Rhine-Westphalia", "state_district" to "Regierungsbezirk Köln"),
@@ -1005,6 +1138,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Köln, NRW",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Germany", "country_code" to "de", "county" to "Bayern", "hamlet" to "Köln", "state" to "Free State of Bavaria", "state_district" to "Upper Bavaria"),
@@ -1015,6 +1149,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Köln, hamlet",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address100" to "Bonn", "country" to "Germany", "country_code" to "de"),
@@ -1024,6 +1159,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bonn formatting",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Berlin", "city_district" to "Mitte", "country" to "Germany", "country_code" to "DE", "house_number" to "1", "neighbourhood" to "Scheunenviertel", "postcode" to "10119", "restaurant" to "Fabisch", "road" to "Rosenthaler Straße", "state" to "Berlin", "suburb" to "Mitte"),
@@ -1035,6 +1171,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Fabisch",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Mitte", "country" to "Germany", "country_code" to "DE", "house_number" to "1", "neighbourhood" to "Scheunenviertel", "postcode" to "10119", "restaurant" to "Fabisch", "road" to "Rosenthaler Straße", "state" to "Berlin", "suburb" to "Mitte"),
@@ -1046,6 +1183,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Fabisch no city",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Heyerode", "continent" to "Europa", "country" to "Germany", "country_code" to "de", "county" to "Unstrut-Hainich-Kreis", "postcode" to "99988", "state" to "Thüringen", "village" to "Heyerode"),
@@ -1055,6 +1193,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Heyerode",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Germany", "country_code" to "de", "state" to "Berlin"),
@@ -1064,6 +1203,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Berlin state",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Landstuhl", "country" to "Germany", "country_code" to "de", "county" to "Landstuhl", "postcode" to "66849", "road" to "Bahnstraße", "state" to "Rhineland-Palatinate", "station" to "Landstuhl", "suburb" to "Melkerei"),
@@ -1075,6 +1215,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no middle comma",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Munich", "city_district" to "Stadtbezirk 03 Maxvorstadt", "country" to "Germany", "country_code" to "de", "state" to "Free State of Bavaria", "state_district" to "Upper Bavaria"),
@@ -1086,6 +1227,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Maxvorstadt, Munich",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "DS Smith Paper Deutschland GmbH", "country" to "Germany", "country_code" to "de", "county" to "Aschaffenburg", "postcode" to "63739,63741,63743", "road" to "Haselmühlweg", "state" to "Free State of Bavaria", "state_district" to "Lower Franconia", "suburb" to "Damm", "town" to "Aschaffenburg"),
@@ -1097,6 +1239,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "multiple postcodes 49.9886629614539, 9.1545295715332",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Ortsbeirat 5 : Lütten Klein", "country" to "Germany", "country_code" to "de", "county" to "Rostock", "house_number" to "30", "postcode" to "18107", "road" to "Turkuer Straße", "state" to "Mecklenburg-Vorpommern", "suburb" to "Lütten Klein"),
@@ -1107,6 +1250,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no city, use county (Kreis)",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Rhein-Sieg-Kreis", "country" to "Germany", "country_code" to "de", "county" to "Rhein-Sieg-Kreis", "house_number" to "18", "neighbourhood" to "Honnef", "postcode" to "53604", "road" to "Bahnhofstraße", "state" to "North Rhine-Westphalia", "state_district" to "Cologne Government Region", "suburb" to "Bondorf", "town" to "Bad Honnef", "unknown" to "Strich nach Punkt"),
@@ -1118,6 +1262,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "city and town",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Berlin", "country" to "Germany", "country_code" to "de", "house_number" to "29A", "local_administrative_area" to "Pankow", "neighbourhood" to "Kollwitzkiez", "postcode" to "10405", "road" to "Jablonskistraße", "state" to "Berlin", "state_code" to "BE", "suburb" to "Prenzlauer Berg"),
@@ -1128,6 +1273,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "local_administrative_area and town in Berlin",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Langenau", "country" to "Deutschland", "country_code" to "de", "county" to "Alb-Donau-Kreis", "hamlet" to "Witthau", "house_number" to "3", "municipality" to "GVV Langenau", "postcode" to "89129", "state" to "Baden-Württemberg", "state_code" to "BW", "town" to "Langenau"),
@@ -1138,6 +1284,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house in hamlet with no road 48.474124, 10.017457",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Germany", "country_code" to "de", "county" to "Sächsische Schweiz-Osterzgebirge", "postcode" to "01744", "state" to "Saxony", "state_code" to "SN", "town" to "Dippoldiswalde", "village" to "Oberhäslich"),
@@ -1147,6 +1294,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village and town",
         fileName = "countries - de",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Djibouti", "country" to "Djibouti", "country_code" to "dj", "neighbourhood" to "Place Mahmoud Harbi", "restaurant" to "Blue Nile", "road" to "Ethiopia Street", "state" to "Djibouti", "suburb" to "District 1"),
@@ -1158,6 +1306,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Djibouti (city), 11.59302,43.14587",
         fileName = "countries - dj",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Denmark", "country_code" to "dk", "county" to "Ærø Municipality", "house_number" to "17A", "neighbourhood" to "Paradiset", "postcode" to "5970", "road" to "Baggårde", "state" to "Region of Southern Denmark", "village" to "Ærøskøbing"),
@@ -1168,6 +1317,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "54.89107,10.40924",
         fileName = "countries - dk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Dominica", "country_code" to "dm", "post_office" to "General Post Office", "postcode" to "00109-800", "road" to "Drury Lane", "state" to "Saint George Parish", "suburb" to "Potters Ville", "town" to "Roseau"),
@@ -1179,6 +1329,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Roseau, 15.29811,-61.38928",
         fileName = "countries - dm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Banco de Reservas", "city" to "Santo Domingo", "country" to "Dominican Republic", "country_code" to "do", "neighbourhood" to "El Manguito", "postcode" to "10102", "road" to "Avenida Jiménez Moya", "state" to "Distrito Nacional", "suburb" to "Ensanche Evoristo Morales"),
@@ -1192,6 +1343,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Santo Domingo",
         fileName = "countries - do",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Algeria", "country_code" to "dz", "county" to "Alger Centre", "hotel" to "Hôtel Régina", "postcode" to "16004", "road" to "Boulevard Mustapha Benboulaid", "state" to "Algiers", "town" to "Alger Centre"),
@@ -1203,6 +1355,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Algiers, 36.77428,3.05945",
         fileName = "countries - dz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Centro de Matematica", "city" to "Quito", "city_district" to "Quito", "country" to "Ecuador", "country_code" to "ec", "county" to "Quito", "postcode" to "170521", "road" to "Jerónimo Leiton", "state" to "Pichincha", "suburb" to "Rumipamba"),
@@ -1215,6 +1368,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "University building in Quito, -0.19972,-78.50708",
         fileName = "countries - ec",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tallinn", "country" to "Estonia", "country_code" to "ee", "county" to "Harju maakond", "house_number" to "15", "postcode" to "10613", "road" to "Kasvu", "suburb" to "Kristiine linnaosa"),
@@ -1225,6 +1379,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Tallinn street address - 59.430702, 24.714138",
         fileName = "countries - ee",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Giza", "country" to "Egypt", "country_code" to "eg", "museum" to "National Cultural Centre", "postcode" to "11231", "road" to "Mahmoud Mokhtar", "state" to "Giza Governorate", "suburb" to "Dokki"),
@@ -1238,6 +1393,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Cultural Centre in Giza, 30.04248,31.22369",
         fileName = "countries - eg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Cairo", "country" to "Egypt", "country_code" to "eg", "postcode" to "11381", "road" to "Fakhry Abdel-Nur", "state" to "Cairo Governorate", "suburb" to "Abbasseya", "university" to "Police Academy"),
@@ -1251,6 +1407,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Policy academy, 30.06864,31.28709",
         fileName = "countries - eg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Luxor", "country" to "Egypt", "country_code" to "eg", "pedestrian" to "Sphinx Alley", "place_of_worship" to "Abu Haggag Mosque", "state" to "Luxor Governate"),
@@ -1262,6 +1419,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Mosque, 25.69992,32.63965",
         fileName = "countries - eg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tanta", "college" to "Tanta University", "country" to "Egypt", "country_code" to "eg", "postcode" to "31111", "road" to "Mohebb", "state" to "Gharbiyya Governorate", "suburb" to "Mahlet Marhoum"),
@@ -1275,6 +1433,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "University, 30.79623,30.99934",
         fileName = "countries - eg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "‏طنطا", "college" to "جامعة طنطا", "country" to "مصر", "country_code" to "eg", "postcode" to "31111", "road" to "شارع محب", "state" to "‏محافظة الغربي", "suburb" to "محلة مرحوم"),
@@ -1288,6 +1447,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Same univerisity, language=ar, 30.79623,2C30.99934",
         fileName = "countries - eg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Western Sahara", "country_code" to "eh", "county" to "Pachalik de Laâyoune", "hotel" to "Hôtel Al-Massira", "postcode" to "70036", "road" to "Boulevard de la Mecque", "state_district" to "Laayoune Province"),
@@ -1299,6 +1459,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Laayoune, 27.15658,-13.20123",
         fileName = "countries - eh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Asmara", "country" to "Eritrea", "country_code" to "er", "courthouse" to "High Court of Eritrea", "postcode" to "1004", "road" to "Harnet Avenue", "state" to "Maekel Region"),
@@ -1310,6 +1471,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Court in Asmara, 15.33621,38.94195",
         fileName = "countries - er",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Barcelona", "country" to "Spain", "country_code" to "es", "county" to "BCN", "state" to "Catalonia"),
@@ -1320,6 +1482,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Barcelona",
         fileName = "countries - es",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Barcelona", "country" to "Spain", "country_code" to "es", "county" to "BCN", "house_number" to "17", "pedestrian" to "Avinguda del Bogatell", "postcode" to "08005", "public_building" to "Biblioteca Xavier Benguerel", "state" to "Catalonia", "suburb" to "la Vila Olímpica del Poblenou"),
@@ -1331,6 +1494,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "41.39266,2.19790",
         fileName = "countries - es",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "San Sebastián", "country" to "Spain", "country_code" to "es", "county" to "Gipuzkoa", "postcode" to "20001;20002;20003;20004;20005;20006;20007;20008;20009;20010;20011;20012;20013;20014;20015;20016;20017;20018", "state" to "Basque Country"),
@@ -1341,6 +1505,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Donostia multipostcode, reject long postcode",
         fileName = "countries - es",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Spanien", "country_code" to "es", "county" to "Costa del Sol Occidental", "state" to "Andalusien"),
@@ -1351,6 +1516,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Costa del Sol Occidental",
         fileName = "countries - es",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Addis Abeba", "country" to "Ethiopia", "country_code" to "et", "library" to "National Library & Archives", "postcode" to "3001", "road" to "Yared Street", "state" to "Addis Ababa", "suburb" to "Beherawi"),
@@ -1362,6 +1528,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Swakopmund, -22.67877,14.52302",
         fileName = "countries - et",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Helsinki", "country" to "Finland", "country_code" to "fi", "county" to "Helsingin seutukunta", "house_number" to "15", "postcode" to "00140", "restaurant" to "Ravintola Central", "road" to "Pietarinkatu", "state" to "Southern Finland", "state_district" to "Southern Finland", "suburb" to "Ullanlinna"),
@@ -1373,6 +1540,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "restaurant Helsinki",
         fileName = "countries - fi",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Suva", "country" to "Fiji", "country_code" to "fj", "library" to "Suva City Library", "road" to "Victoria Parade", "state" to "Central", "suburb" to "The Domain"),
@@ -1384,6 +1552,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Suva, -18.14221,178.42309",
         fileName = "countries - fj",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Rose Hotel", "country" to "Falkland Islands", "country_code" to "fk", "house_number" to "1", "residential" to "Port Stanley", "road" to "Brisbane Road", "town" to "Stanley"),
@@ -1396,6 +1565,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Stanley, -51.69328,-57.86325",
         fileName = "countries - fk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("continent" to "South America", "country" to "Falkland Islands", "country_code" to "fk"),
@@ -1405,6 +1575,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "middle of nowhere, -51.70,-58.62",
         fileName = "countries - fk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Federated States of Micronesia", "country_code" to "fm", "library" to "Pohnpei Public Library", "postcode" to "96941", "road" to "Kaselehlia", "state" to "Pohnpei", "town" to "Kolonia"),
@@ -1416,6 +1587,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "library in Kolonia, 6.95813,158.20911",
         fileName = "countries - fm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bank Nordik", "country" to "Territorial waters of Faroe Islands", "country_code" to "fo", "house_number" to "17", "postcode" to "100", "road" to "Steinagøta", "state" to "Streymoy region", "town" to "Tórshavn"),
@@ -1427,6 +1599,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Tórshavn, 62.01111,-6.77396",
         fileName = "countries - fo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Toulouse", "country" to "France", "country_code" to "FR", "county" to "Toulouse", "house_number" to "17", "neighbourhood" to "Lafourguette", "postcode" to "31000", "road" to "Rue du Médecin-Colonel Calbairac", "state" to "Midi-Pyrénées", "suburb" to "Toulouse Ouest"),
@@ -1437,6 +1610,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Toulouse",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Mulhouse", "country" to "France", "country_code" to "fr", "county" to "Mulhouse", "postcode" to "68100;68200", "state" to "Alsace-Champagne-Ardenne-Lorraine"),
@@ -1446,6 +1620,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "remove postcode range",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Cayenne", "house_number" to "53", "neighbourhood" to "Cité Floralies", "postcode" to "97300", "road" to "Rue du Lieutenant Becker", "state" to "French Guiana", "town" to "Cayenne"),
@@ -1456,6 +1631,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Cayenne, 4.93802,-52.32985",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Mairie (bureaux administratifs)", "city" to "Papeete", "country" to "Polynésie française, Îles du Vent (eaux territoriales)", "country_code" to "fr", "county" to "Îles du Vent", "postcode" to "98714", "road" to "Rue des Remparts", "state" to "French Polynesia"),
@@ -1467,6 +1643,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Office in Papeete, -17.53714,-149.56608",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Conseil Général de Mayotte", "country" to "France, Mayotte (eaux territoriales)", "country_code" to "fr", "postcode" to "97600", "road" to "Rue Houmadi Bacar", "state" to "Mayotte", "town" to "Mamoudzou"),
@@ -1478,6 +1655,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Government building in Mamoudzou, -12.77958,45.23145",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Le Port", "country" to "France, La Réunion (eaux territoriales)", "country_code" to "fr", "county" to "Saint-Paul", "house_number" to "17", "postcode" to "97420", "road" to "Rue François de Mahy", "state" to "Réunion"),
@@ -1488,6 +1666,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Le Port, -20.93750,55.29020",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Société nouvelle des pêches de Miquelon", "city" to "Miquelon-Langlade", "country" to "France", "country_code" to "fr", "postcode" to "97500", "road" to "Rue Jacques Vigneau", "state" to "Saint Pierre and Miquelon"),
@@ -1499,6 +1678,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Miquelon, 47.10099,-56.37706",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Immeuble Maréchal Foch", "city" to "Nouméa", "city_district" to "Secteur Ouest", "country" to "France, Nouvelle-Calédonie, Grande Terre et récifs d'Entrecasteaux (eaux territoriales)", "country_code" to "fr", "county" to "Province Sud", "postcode" to "98800", "road" to "Rue Jean Jaurès", "state" to "New Caledonia", "suburb" to "Centre-Ville"),
@@ -1510,6 +1690,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Nouméa, -22.27039,166.44270",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Fontainebleau", "postcode" to "77630", "road" to "Autoroute du Soleil", "road_reference" to "A 6", "road_reference_intl" to "E 15", "state" to "Ile-de-France", "village" to "Arbonne-la-Forêt"),
@@ -1520,6 +1701,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "road, 48.406168,2.55452",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Fontainebleau", "postcode" to "77630", "road_reference" to "A 6", "road_reference_intl" to "E 15", "state" to "Ile-de-France", "village" to "Arbonne-la-Forêt"),
@@ -1530,6 +1712,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "road_reference, 48.406168,2.55452",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Fontainebleau", "postcode" to "77630", "road_reference_intl" to "E 15", "state" to "Ile-de-France", "village" to "Arbonne-la-Forêt"),
@@ -1540,6 +1723,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "road_reference_intl, 48.406168,2.55452",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("amenity" to "A1X4E0", "country" to "France", "country_code" to "fr", "county" to "Var", "municipality" to "Draguignan", "postcode" to "83700", "road" to "Avenue du XVe Corps", "state" to "Provence-Alpes-Côte dAzur", "suburb" to "Valescure", "town" to "Saint-Raphaël"),
@@ -1551,6 +1735,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "43.42981,6.77514",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Paris 7e Arrondissement", "country" to "France", "country_code" to "fr", "house_number" to "15", "postcode" to "75007", "state" to "Île-de-France", "state_district" to "Paris", "street" to "Avenue Charles Floquet"),
@@ -1561,6 +1746,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "48.8564, 2.2961",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Isère", "house_number" to "83", "municipality" to "Grenoble", "neighbourhood" to "Lotissement des cartonneries", "postcode" to "38560", "road" to "Avenue Jean Navarre", "state" to "Auvergne-Rhône-Alpes", "state_code" to "ARA", "village" to "Champ-sur-Drac"),
@@ -1571,6 +1757,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "45.08523,5.73302",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Doubs", "hamlet" to "Les Communaux", "house_number" to "20", "municipality" to "Pontarlier", "postcode" to "25500", "road" to "Rue Antoine de Roche", "state" to "Bourgogne-Franche-Comté", "state_code" to "BFC", "town" to "Morteau"),
@@ -1581,6 +1768,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "7.06073496297967,6.60534772183623",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "fr", "county" to "Bas-Rhin", "municipality" to "Haguenau-Wissembourg", "postcode" to "67500", "region" to "Metropolitan France", "road" to "Rue des Voituriers", "state" to "Grand Est", "state_code" to "GES", "town" to "Haguenau"),
@@ -1591,6 +1779,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "48.80868,7.78761",
         fileName = "countries - fr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Consulat De France", "city" to "Libreville", "country" to "Gabon", "country_code" to "ga", "county" to "Libreville Department", "neighbourhood" to "Batavea", "postcode" to "BP13131", "road" to "Rue Ange M'ba", "state" to "Estuaire", "suburb" to "Nombakele"),
@@ -1603,6 +1792,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Librevill, 0.38899,9.44561",
         fileName = "countries - ga",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "city_district" to "London Borough of Islington", "country" to "United Kingdom", "country_code" to "GB", "house" to "Lokku Ltd", "house_number" to "82", "postcode" to "EC1M 5RF", "road" to "Clerkenwell Road", "state" to "England", "state_district" to "Greater London", "suburb" to "Clerkenwell"),
@@ -1615,6 +1805,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Lokku office",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United Kingdom", "country_code" to "GB", "county" to "Greater London", "local_administrative_area" to "City of London", "state" to "England", "suburb" to "Barbican"),
@@ -1626,6 +1817,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Lokku office",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "country" to "United Kingdom", "country_code" to "GB", "county" to "London", "state" to "England", "state_district" to "Greater London"),
@@ -1635,6 +1827,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "London",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Manchester", "country" to "United Kingdom", "country_code" to "GB", "county" to "Manchester", "state" to "England"),
@@ -1645,6 +1838,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Manchester",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "city_district" to "London Borough of Islington", "country" to "United Kingdom", "country_code" to "gb", "county" to "London", "state" to "England", "state_district" to "Greater London", "suburb" to "Clerkenwell"),
@@ -1655,6 +1849,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "just a suburb",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "City of Westminster", "country" to "United Kingdom", "country_code" to "gb", "county" to "London", "house_number" to "115", "postcode" to "W1T 5DU", "road" to "New Cavendish Street", "state" to "England", "state_district" to "Greater London", "suburb" to "Fitzrovia", "university" to "University of Westminster"),
@@ -1667,6 +1862,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "City of Westminster, 51.52089885, -0.14007993",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United Kingdom", "country_code" to "gb", "county" to "Cambridgeshire", "postcode" to "PE28 9QA", "region" to "East of England", "state" to "England", "suburb" to "Fenstanton", "town" to "Huntingdonshire", "village" to "Hilton"),
@@ -1677,6 +1873,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village in Cambridgeshire, 52.281523,-0.115179",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Willoughby House", "city" to "London", "country" to "United Kingdom", "country_code" to "gb", "county" to "City of London", "postcode" to "EC2Y 9DP", "quarter" to "Barbican", "road" to "Moor Lane", "state" to "England", "state_district" to "Greater London"),
@@ -1690,6 +1887,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Willoughby House, Barbican",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "City of Nottingham", "country" to "United Kingdom", "country_code" to "gb", "house_number" to "121", "neighbourhood" to "Lace Market", "postcode" to "NG3 1NB", "road" to "Abbotsford Drive", "state" to "England", "state_district" to "East Midlands", "suburb" to "St Ann's"),
@@ -1701,6 +1899,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "City of Nottingham",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "country" to "United Kingdom", "country_code" to "gb", "county" to "London Borough of Waltham Forest", "house_number" to "64", "neighbourhood" to "Walthamstow Village", "postcode" to "E10", "road" to "Melbourne Road", "state" to "England", "state_district" to "Greater London", "suburb" to "Leyton"),
@@ -1712,6 +1911,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "London Borough of Waltham Forest",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "country" to "United Kingdom", "country_code" to "gb", "county" to "London Borough of Waltham Forest", "house_number" to "64", "neighbourhood" to "Walthamstow Village", "partial_postcode" to "E10", "road" to "Melbourne Road", "state" to "England", "state_district" to "Greater London", "suburb" to "Leyton"),
@@ -1723,6 +1923,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "London Borough of Waltham Forest - partial_postcode",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Orchard House", "city" to "Wakefield", "country" to "United Kingdom", "country_code" to "gb", "county" to "West Yorkshire", "postcode" to "WF5 8PG", "road" to "West Wells Road", "state" to "England", "state_code" to "ENG", "state_district" to "Yorkshire and the Humber", "town" to "Ossett"),
@@ -1735,6 +1936,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Prefer town over city (Ossett vs Wakefield)",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United Kingdom", "country_code" to "gb", "county" to "York", "farmland" to "Fair Field", "hamlet" to "Kexby", "state" to "England", "state_district" to "Yorkshire and the Humber"),
@@ -1747,6 +1949,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Farmland",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "city_district" to "London Borough of Hackney", "country" to "United Kingdom", "country_code" to "gb", "state" to "England", "state_code" to "ENG", "state_district" to "Greater London", "suburb" to "Hoxton"),
@@ -1757,6 +1960,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "suburb before city_district",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Stratford-on-Avon", "country" to "United Kingdom", "country_code" to "gb", "county" to "Warwickshire", "state" to "England", "village" to "Welford on Avon CP"),
@@ -1769,6 +1973,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village and city",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "East Hertfordshire", "country" to "United Kingdom", "country_code" to "gb", "county" to "Hertfordshire", "county_code" to "HRT", "state" to "England", "state_code" to "ENG", "town" to "Bishop's Stortford"),
@@ -1780,6 +1985,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "town and city",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "London", "country" to "United Kingdom", "country_code" to "gb", "house" to "St. Judes & St. Pauls C of E (Va) Primary School", "house_number" to "10", "postcode" to "N1 4AZ", "road" to "Kingsbury Road"),
@@ -1792,6 +1998,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "place name with & in name",
         fileName = "countries - gb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Republic Bank Grenada", "city" to "St. George's", "country" to "Grenada", "country_code" to "gd", "road" to "Bruce Street", "suburb" to "Belmont"),
@@ -1803,6 +2010,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in St. George's, 12.05197,-61.75459",
         fileName = "countries - gd",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bar" to "Mojito Bar", "city" to "Tbilisi", "country" to "Georgia", "country_code" to "GE", "house_number" to "7", "postcode" to "0114", "road" to "Cotton Row", "suburb" to "Old Tbilisi Raion"),
@@ -1814,6 +2022,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Tbilisi",
         fileName = "countries - ge",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "French Guiana", "country_code" to "gf", "county" to "Cayenne", "house_number" to "53", "neighbourhood" to "Cité Floralies", "postcode" to "97300", "road" to "Rue du Lieutenant Becker", "state" to "French Guiana", "town" to "Cayenne"),
@@ -1824,6 +2033,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Cayenne, 4.93802,-52.32985",
         fileName = "countries - gf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Guernsey", "country_code" to "gg", "post_box" to "Post Office", "postcode" to "GY1", "road" to "Le Marchant Street", "state" to "Guernsey", "town" to "Saint Peter Port"),
@@ -1836,6 +2046,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Saint Peter Port, 49.45676,-2.53688",
         fileName = "countries - gg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Ecobank", "city" to "Accra", "country" to "Ghana", "country_code" to "gh", "county" to "Accra Metropolitan", "postcode" to "233", "road" to "7th Avenue", "state" to "Greater Accra Region", "suburb" to "West Ridge"),
@@ -1847,6 +2058,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Accra, 5.56008,-0.20236",
         fileName = "countries - gh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Gibraltar", "country_code" to "gi", "house_number" to "18-20", "museum" to "Gibraltar Museum", "pedestrian" to "Bomb House Lane", "town" to "Gibraltar"),
@@ -1857,6 +2069,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Gibraltar, 36.13887,-5.35441",
         fileName = "countries - gi",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nuuk", "country" to "Greenland", "country_code" to "gl", "house_number" to "18", "neighbourhood" to "Qernertunnguit", "pedestrian" to "Imaneq", "postcode" to "3900", "suburb" to "Qaurunnguaq"),
@@ -1867,6 +2080,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Nuuk, 64.17660,-51.73981",
         fileName = "countries - gl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Banjul", "country" to "The Gambia", "country_code" to "gm", "library" to "Gambia National Library", "road" to "Reg Pye Lane", "state" to "Banjul"),
@@ -1878,6 +2092,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Banjul, 13.45956,-16.58501",
         fileName = "countries - gm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Kaloum", "country" to "Guinea", "country_code" to "gn", "furniture" to "L'Art de la Table", "road" to "8e Avenue", "state" to "Conakry", "suburb" to "Almamiya 2"),
@@ -1890,6 +2105,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Conakry, 9.51087,-13.71186",
         fileName = "countries - gn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Guadeloupe", "country_code" to "gp", "county" to "Pointe-à-Pitre", "museum" to "Musée Lherminier", "postcode" to "97110", "road" to "Rue Sadi-Carnot", "state" to "Guadeloupe", "suburb" to "Centre-Ville", "town" to "Pointe-à-Pitre"),
@@ -1901,6 +2117,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Pointe-à-Pitre, 16.23832,-61.53703",
         fileName = "countries - gp",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Malabo", "country" to "Equatorial Guinea", "country_code" to "gq", "neighbourhood" to "Los Ángeles", "restaurant" to "Treasure Island", "road" to "Av de la Independencia", "state" to "Bioko Norte", "suburb" to "Santa Isabel"),
@@ -1912,6 +2129,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Malabo, 3.75719,8.78163",
         fileName = "countries - gq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "National Bank of Greece", "city" to "Municipality of Athens", "country" to "Greece", "country_code" to "GR", "county" to "Central Athens Regional Unit", "house_number" to "11", "neighbourhood" to "Kolonaki", "postcode" to "10673", "road" to "Skoufa street", "state" to "Attica Administration", "state_district" to "Attica"),
@@ -1923,6 +2141,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bank in Greece",
         fileName = "countries - gr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "South Georgia and the South Sandwich Islands", "country_code" to "gs", "hamlet" to "Grytviken", "museum" to "South Georgia Museum", "state" to "South Georgia"),
@@ -1934,6 +2153,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Grytviken, -54.28012,-36.50793",
         fileName = "countries - gs",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Banco Reformador", "city" to "Guatemala City", "country" to "Guatemala", "country_code" to "gt", "county" to "Guatemala City", "house_number" to "18 calle 3-70 Zona 1", "postcode" to "01004", "road" to "Transmetro Eje Sur", "state" to "Guatemala", "suburb" to "Zona 1"),
@@ -1945,6 +2165,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Guatemala City, 14.63133,-90.51752",
         fileName = "countries - gt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Guam", "country_code" to "gu", "county" to "Guam", "house_number" to "258", "postcode" to "96913", "road" to "Father San Vitores Street", "state" to "Guam", "town" to "Tamuning"),
@@ -1955,6 +2176,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Tamuning, 13.50294,144.77693",
         fileName = "countries - gu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Embaixada d'Espanha", "city" to "Bissau", "country" to "Guinea-Bissau", "country_code" to "gw", "neighbourhood" to "Tchada", "road" to "Praça dos Herois Nacionais", "state" to "Setor autónomo de Bissau", "suburb" to "Reino"),
@@ -1966,6 +2188,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Bissau, 11.86213,-15.58436",
         fileName = "countries - gw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Scotiabank (Carmichael St. Branch)", "city" to "Georgetown", "country" to "Guyana", "country_code" to "gy", "county" to "Demerara-Mahaica Region", "postcode" to "101147", "road" to "Carmichael Street"),
@@ -1977,6 +2200,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Georgetown, 6.81913,-58.16213",
         fileName = "countries - gy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cinema" to "Chinachem Golden Plaza Cinema", "country" to "Hong Kong", "country_code" to "hk", "county" to "Yau Tsim Mong District", "road" to "Science Museum Road", "state" to "Hong Kong", "state_district" to "Kowloon", "suburb" to "Tsim Sha Tsui"),
@@ -1988,6 +2212,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Cinema in HK, 22.29987,114.17933",
         fileName = "countries - hk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Hong Kong", "country" to "Hong Kong", "country_code" to "hk", "road" to "211 Test Street"),
@@ -1997,6 +2222,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "just city, no state",
         fileName = "countries - hk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Heard Island and McDonald Islands", "country_code" to "hm", "island" to "Heard Island"),
@@ -2007,6 +2233,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Glacier on Heard Island, -53.0571,73.4339",
         fileName = "countries - hm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tegucigalpa", "country" to "Honduras", "country_code" to "hn", "county" to "Tegucigalpa", "footway" to "Paseo Liquidambar", "post_office" to "Correo Nacional de Honduras", "postcode" to "504", "state" to "Francisco Morazán", "suburb" to "El Jazmin"),
@@ -2018,6 +2245,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "post office in Tegucigalpa, 14.10631,-87.20813",
         fileName = "countries - hn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dubrovnik", "country" to "Croatia", "country_code" to "hr", "county" to "Dubrovnik-Neretva", "house_number" to "2", "postcode" to "20000", "road" to "Marijana Blazica", "suburb" to "Pile"),
@@ -2028,6 +2256,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hotel in Dubrovnik - 42.64286,18.10394",
         fileName = "countries - hr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Banque de l'Union Haitienne SA", "city" to "Commune de Port-au-Prince", "country" to "Haiti", "country_code" to "ht", "postcode" to "HT6114", "road" to "Rue Bonne Foi", "state" to "Département de l'Ouest", "state_district" to "Port-au-Prince", "suburb" to "6e Turgeau"),
@@ -2039,6 +2268,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Port-au-Prince, 18.55005,-72.34510",
         fileName = "countries - ht",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Budapest", "city_district" to "1. kerület", "country" to "Hungary", "country_code" to "hu", "county" to "Budapesti kistérség", "house_number" to "11", "neighbourhood" to "Naphegy", "postcode" to "1016", "road" to "Dezső utca", "state" to "Közép-Magyarország", "state_district" to "Central Hungary", "suburb" to "Krisztinaváros"),
@@ -2049,6 +2279,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house in Budapest - 47.49269,19.03371",
         fileName = "countries - hu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bar" to "Moodz Gastro Bar", "city" to "RW 05", "city_district" to "1. kerület", "country" to "Indonesia", "country_code" to "ID", "postcode" to "12960", "road" to "Epicentrum Boulevard Barat", "state" to "Jakarta Special Capital Region"),
@@ -2062,6 +2293,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Jakarta",
         fileName = "countries - id",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Galway City", "country" to "Ireland", "country_code" to "ie", "county" to "Galway City", "house_number" to "8-9", "road" to "Mainguard Street", "state_district" to "Connacht", "suburb" to "Claddagh"),
@@ -2073,6 +2305,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Galway",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Ireland", "country_code" to "ie", "county" to "Kilkenny", "state" to "Leinster", "town" to "Kilkenny"),
@@ -2082,6 +2315,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Kilkenny",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Ireland", "country_code" to "ie", "county" to "County Kilkenny", "residential" to "Friar's Hill", "state_district" to "Leinster", "town" to "Graiguenamanagh"),
@@ -2093,6 +2327,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Friar's Hill, Graiguenamanagh",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dublin", "city_district" to "Wood Quay A ED", "continent" to "Europe", "country" to "Ireland", "country_code" to "ie", "county" to "County Dublin", "county_code" to "D", "library" to "The National Archives", "postcode" to "D02 TD99", "road" to "Bishop Street", "state" to "Leinster", "state_code" to "L"),
@@ -2106,6 +2341,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "condense \"Dublin, County Dublin\"",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "The Metropolitan District of Limerick City", "city_district" to "Farranshone", "country" to "Ireland", "country_code" to "ie", "county" to "County Limerick", "county_code" to "LK", "locality" to "Farranshone Beg", "road" to "Shelbourne Road", "road_reference" to "R464", "state" to "Munster"),
@@ -2117,6 +2353,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "remove \"The Metropolitan District of\"",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city_district" to "Clifden Electoral Division", "continent" to "Europe", "country" to "Ireland", "country_code" to "ie", "county" to "County Galway", "county_code" to "G", "guest_house" to "Connemara Country Lodge", "region" to "Conamara Municipal District", "road" to "N59", "state" to "Connacht", "state_code" to "C", "town" to "Clifden"),
@@ -2129,6 +2366,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no \"Electoral Division\"",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "G", "city_district" to "Maynooth ED", "continent" to "Europe", "country" to "Ireland", "country_code" to "ie", "county" to "County Kildare", "county_code" to "KE", "postcode" to "W23P466", "region" to "The Municipal District of Clane — Maynooth", "road" to "Ballygoran Road"),
@@ -2142,6 +2380,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "format Eircode correctly (no spaces)",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "G", "city_district" to "Maynooth ED", "continent" to "Europe", "country" to "Ireland", "country_code" to "ie", "county" to "County Kildare", "county_code" to "KE", "postcode" to "W23-P466", "region" to "The Municipal District of Clane — Maynooth", "road" to "Ballygoran Road"),
@@ -2155,6 +2394,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "format Eircode correctly (dash)",
         fileName = "countries - ie",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tel Aviv-Yafo", "country" to "Israel", "country_code" to "il", "house_number" to "29", "postcode" to "64739", "residential" to "Tel Aviv", "road" to "Yizhak Sadeh", "state" to "Tel Aviv District", "suburb" to "Montefiore"),
@@ -2165,6 +2405,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Tel Aviv, 32.06523,34.78793",
         fileName = "countries - il",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "3FM", "country" to "Isle of Man", "country_code" to "im", "county" to "Middle", "house_number" to "45", "postcode" to "IM1 2AY", "road" to "Victoria Street", "town" to "Douglas"),
@@ -2177,6 +2418,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Douglas, 54.14906,-4.47949",
         fileName = "countries - im",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("road" to "uppuguda", "city" to "Hyderabad", "neighbourhood" to "Patthergatti", "country" to "India", "country_code" to "IN", "postcode" to "500064", "restaurant" to "Anand Bhavan (vegetarian)", "state" to "Telangana", "suburb" to "Charminar"),
@@ -2190,6 +2432,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Hyderabad",
         fileName = "countries - in",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("state" to "Mahārāshtra", "postcode" to "400096", "country" to "India", "country_code" to "in"),
@@ -2200,6 +2443,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Indian postcode",
         fileName = "countries - in",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Pune", "country" to "India", "country_code" to "in", "road" to "Baner", "state" to "Maharashtra"),
@@ -2211,6 +2455,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "without postcode",
         fileName = "countries - in",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "British Indian Ocean Territory", "country_code" to "io", "road" to "DG1", "village" to "Seabreeze Village"),
@@ -2222,6 +2467,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Road on Diego Garcia, -7.3153,72.4268",
         fileName = "countries - io",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Baghdad", "city_district" to "Rusafa", "country" to "Iraq", "country_code" to "iq", "county" to "Al Resafa", "postcode" to "222", "road" to "A86/N11/D383", "state" to "Baghdad", "suburb" to "Mustansiriya", "supermarket" to "al mustansriya Central Market"),
@@ -2235,6 +2481,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 33.3559,44.4015",
         fileName = "countries - iq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "بغداد", "city_district" to "Rusafa", "country" to "العراق", "country_code" to "iq", "county" to "Al Resafa", "postcode" to "222", "road" to "A86/N11/D383", "state" to "محافظة بغداد", "suburb" to "Mustansiriya", "supermarket" to "al mustansriya Central Market"),
@@ -2248,6 +2495,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, language=ar, 33.3559,44.4015",
         fileName = "countries - iq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Mosul", "country" to "Iraq", "country_code" to "iq", "county" to "Al Mnsul Qadha", "hospital" to "Mosul General Hospital", "road" to "الجسر الرابع", "state" to "Nineveh", "suburb" to "وادي حجر"),
@@ -2260,6 +2508,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hospital, 36.32326,43.12339",
         fileName = "countries - iq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Baghdad", "city_district" to "Rasheed", "country" to "Iraq", "country_code" to "iq", "county" to "Karkh", "road" to "شارع قطر الندى", "state" to "Baghdad", "suburb" to "Resala", "townhall" to "Masgd"),
@@ -2272,6 +2521,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Town hall, 33.23623,44.31577",
         fileName = "countries - iq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Arbil", "continent" to "Asia", "country" to "Iraq", "country_code" to "iq", "county" to "قضاء أربيل", "house_number" to "391", "neighbourhood" to "English Village", "postcode" to "44001", "state" to "هەرێمی کوردستان", "suburb" to "گوندی ئینگلیزی"),
@@ -2283,6 +2533,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "36.19137, 43.97445",
         fileName = "countries - iq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("attraction" to "Azadi Tower", "city" to "Tehran", "country" to "Iran", "country_code" to "ir", "postcode" to "1351956118", "road" to "Azadi Square", "suburb" to "Ostad Moein"),
@@ -2296,6 +2547,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Tower in Tehran, 35.699,51.33810",
         fileName = "countries - ir",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tehran", "country" to "Iran", "country_code" to "ir", "district" to "بخش مرکزی شهرستان تهران", "province" to "Tehran Province"),
@@ -2306,6 +2558,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "district should be treated as alias of state_district",
         fileName = "countries - ir",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Reykjavik", "country" to "Iceland", "country_code" to "is", "house_number" to "15", "postcode" to "101", "road" to "Bergstaðastræti", "state_district" to "Capital Region", "suburb" to "Austurbær"),
@@ -2316,6 +2569,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Reykjavik, 64.14436,-21.93335",
         fileName = "countries - is",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Barletta", "country" to "Italy", "country_code" to "it", "county" to "BT", "house_number" to "13", "postcode" to "76121", "road" to "Via Pisacane", "state" to "Apulia", "suburb" to "Montaltino"),
@@ -2326,6 +2580,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Barletta street address - 41.312006,16.2704745",
         fileName = "countries - it",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Milano", "country" to "Italy", "country_code" to "it", "county" to "Milano", "postcode" to "20147", "road" to "Via Giovanni Della Casa", "state" to "Lombardy", "suburb" to "Boldinasco"),
@@ -2336,6 +2591,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Milano, correcty add county_code",
         fileName = "countries - it",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "San Raffaele Cimena", "country" to "Italy", "country_code" to "it", "county" to "Torino", "postcode" to "10032", "road" to "Via Pertengo", "state" to "Piemonte"),
@@ -2346,6 +2602,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Torino, correcty add county_code",
         fileName = "countries - it",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "San Raffaele Cimena", "country" to "Italy", "country_code" to "it", "county" to "Provincia di Torino", "postcode" to "10032", "road" to "Via Pertengo", "state" to "Piemonte"),
@@ -2356,6 +2613,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Provincia di Torino, correcty add county_code",
         fileName = "countries - it",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Palazzo Gondi", "city" to "Firenze", "country" to "Italia", "country_code" to "it", "county" to "Città metropolitana di Firenze", "pedestrian" to "Via dei Gondi", "postcode" to "50122", "state" to "TOS", "suburb" to "Quartiere 1"),
@@ -2367,6 +2625,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "deal with Città metropolitana di Firenze",
         fileName = "countries - it",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Jersey", "country_code" to "je", "house_number" to "5", "postcode" to "JE2 4TN", "road" to "Le Geyt Street", "state" to "Jersey", "town" to "Saint Helier"),
@@ -2378,6 +2637,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Saing Helier, 49.18619,-2.10716",
         fileName = "countries - je",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Old Court House", "city" to "Spanish Town", "country" to "Jamaica", "country_code" to "jm", "county" to "Saint Catherine", "neighbourhood" to "Tawes Meadows", "road" to "Constitution Street", "state_district" to "Middlesex County"),
@@ -2390,6 +2650,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "building in Spanish Town, 17.99588,-76.95424",
         fileName = "countries - jm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Amman", "country" to "Jordan", "country_code" to "jo", "museum" to "Jordan National Gallery of Fine Arts, Building 1", "postcode" to "11190", "road" to "Husni Fareez Street", "state" to "Amman"),
@@ -2401,6 +2662,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Gallery, 31.95791,35.91522",
         fileName = "countries - jo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Amman", "country" to "Jordan", "country_code" to "jo", "postcode" to "11183", "road" to "Abu Al Wafa Al Dajani Street", "state" to "Amman", "supermarket" to "هَبوب - Haboob"),
@@ -2412,6 +2674,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 31.95101,35.91891",
         fileName = "countries - jo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "عمان", "country" to "الأردن", "country_code" to "jo", "postcode" to "11183", "road" to "Abu Al Wafa Al Dajani Street", "state" to "‏محافظة العاصمة‎", "supermarket" to "هَبوب"),
@@ -2423,6 +2686,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, language=ar, 31.95101,35.91891",
         fileName = "countries - jo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Khalifeh Mall", "city" to "Amman", "country" to "Jordan", "country_code" to "jo", "postcode" to "11183", "road" to "جبل عرفات", "state" to "Amman", "suburb" to "Sweifieh"),
@@ -2434,6 +2698,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Dental clinic, 31.91740,35.89150",
         fileName = "countries - jo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "خليفة مول", "city" to "عمان", "country" to "الأردن", "country_code" to "jo", "postcode" to "11183", "road" to "جبل عرفات", "state" to "‏محافظة العاصمة‎", "suburb" to "حي الصويفية"),
@@ -2445,6 +2710,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Dental clinic, language=ar, 31.91740,35.89150",
         fileName = "countries - jo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Hiroshima", "country" to "Japan", "country_code" to "jp", "county" to "Aki County", "postcode" to "7300846", "restaurant" to "食辛房", "road" to "舟入通り", "state" to "Chugoku Region", "suburb" to "Naka Ward"),
@@ -2457,6 +2723,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Hiroshima, 34.38227,132.44032",
         fileName = "countries - jp",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Jubilee Insurance Place", "city" to "Nairobi", "country" to "Kenya", "country_code" to "ke", "postcode" to "46464", "road" to "Wabera Street", "state" to "Nairobi", "suburb" to "Madaraka Estate"),
@@ -2469,6 +2736,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in downtown Nairobi -1.28599,36.82206",
         fileName = "countries - ke",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Бишкек", "country" to "Kyrgyzstan", "country_code" to "KG", "county" to "Аламудунский район", "cafe" to "Даамдан", "house_number" to "473", "postcode" to "720033", "road" to "Frunze Mikhail Street", "state" to "Astana"),
@@ -2481,6 +2749,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "null",
         fileName = "countries - kg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Phnom Penh", "country" to "Cambodia", "country_code" to "kh", "hotel" to "Cambodiana", "postcode" to "12301", "road" to "Preah Sisowath Quay", "state" to "Phnom Penh", "suburb" to "Daun Penh"),
@@ -2493,6 +2762,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Phnom Penh, 11.55983,104.93653",
         fileName = "countries - kh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "The ANZ Bank", "city" to "Tarawa Teinainano", "country" to "Kiribati", "country_code" to "ki", "road" to "Postplatz"),
@@ -2504,6 +2774,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Bairiki, 1.33010,172.97850",
         fileName = "countries - ki",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Moroni", "country" to "Comoros", "country_code" to "km", "courthouse" to "Palais de Justice", "road" to "RN2", "state" to "Grande Comore"),
@@ -2515,6 +2786,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "court in Moroni, -11.70181,43.25485",
         fileName = "countries - km",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Saint Kitts and Nevis", "country_code" to "kn", "province" to "Saint Kitts", "restaurant" to "Ballahoo Restaurant", "road" to "Fort Street", "town" to "Basseterre"),
@@ -2526,6 +2798,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in Basseterre, 17.29535,-62.72366",
         fileName = "countries - kn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Pyongyang", "country" to "North Korea", "country_code" to "kp", "library" to "Grand People's Study House", "road" to "Somun Street", "state" to "Pyongyang", "state_district" to "Central District", "suburb" to "동신3동 (Tongsin 3-dong)"),
@@ -2538,6 +2811,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Pyongyang, 39.0203,125.7490",
         fileName = "countries - kp",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Seoul", "city_district" to "서초2동 (Seocho2-dong)", "country" to "South Korea", "country_code" to "kr", "hotel" to "Haeundae Grand Hotel", "postcode" to "135-934", "road" to "Seocho-daero 74-gil", "town" to "Seocho-gu", "village" to "Seocho-dong"),
@@ -2549,6 +2823,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Gangnam, Seoul, 37.49675,127.02755",
         fileName = "countries - kr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Seoul", "country" to "South Korea", "country_code" to "kr", "city_district" to "Gangnam-gu"),
@@ -2559,6 +2834,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "district of Seoul",
         fileName = "countries - kr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Jaleeb Al Shoyoukh", "country" to "Kuwait", "country_code" to "kw", "postcode" to "32018", "road" to "79 St", "state" to "Farwaniya", "suburb" to "Al Dajeej", "supermarket" to "Sultan Center Wholesale"),
@@ -2571,6 +2847,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket at 29.2612,47.9658",
         fileName = "countries - kw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "جليب الشيوخ", "country" to "الكويت", "country_code" to "kw", "postcode" to "32018", "road" to "79 St", "state" to "الفروانية", "suburb" to "الضجيج", "supermarket" to "Sultan Center Wholesale"),
@@ -2583,6 +2860,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, language=ar, 29.2612,47.9658",
         fileName = "countries - kw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Shuwaikh Residential", "country" to "Kuwait", "country_code" to "kw", "hospital" to "Faiha Primary Healthcare Center", "postcode" to "13009", "road" to "Third Ring Road", "state" to "Al Asimah", "suburb" to "Faiha"),
@@ -2595,6 +2873,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hospital, 29.33765,47.97917",
         fileName = "countries - kw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Kuwait National Library", "city" to "Kuwait City", "country" to "Kuwait", "country_code" to "kw", "postcode" to "13009", "road" to "Gulf Road", "state" to "Al Asimah", "suburb" to "Dasma"),
@@ -2607,6 +2886,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "National Library, 29.37496,47.96875",
         fileName = "countries - kw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Butterfield Place", "city" to "George Town", "country" to "Cayman Islands", "country_code" to "ky", "house_number" to "12", "postcode" to "KY1-1103", "road" to "Albert Panton Street", "suburb" to "Rock Hole Road"),
@@ -2618,6 +2898,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "address in George Town, 19.29619,-81.38217",
         fileName = "countries - ky",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Astana", "country" to "Kazakhstan", "country_code" to "KZ", "county" to "район Сарыарка", "name" to "Хива", "house_number" to "24", "postcode" to "010000", "road" to "улица Конституции", "state" to "Astana"),
@@ -2630,6 +2911,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "null",
         fileName = "countries - kz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Vientiane", "country" to "Laos", "country_code" to "la", "postcode" to "01003", "public_building" to "Ministre de la santé", "road" to "Mahosot Road", "state" to "Vientiane Capital"),
@@ -2641,6 +2923,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Govt department building in Vientiane, 17.96306,102.61438",
         fileName = "countries - la",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cinema" to "Circuit Empire Sodeco", "city" to "Beirut", "country" to "Lebanon", "country_code" to "lb", "postcode" to "2052 6703", "road" to "Damascus Road", "state" to "Beirut Governorate", "suburb" to "Achrafieh"),
@@ -2652,6 +2935,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Cinema, 33.88591,35.50907",
         fileName = "countries - lb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cinema" to "سيركوي امبير سوديكو", "city" to "بيروت", "country" to "الجمهورية اللبنانية", "country_code" to "lb", "postcode" to "2052 6703", "road" to "طريق الشام", "state" to "محافظة بيروت", "suburb" to "الأشرفية"),
@@ -2663,6 +2947,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Cinema, language=ar, 33.88591,35.50907",
         fileName = "countries - lb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Beirut", "country" to "Lebanon", "country_code" to "lb", "restaurant" to "Kushari Society", "road" to "Rue Mahatma Gandhi", "state" to "Beirut Governorate", "suburb" to "Ras Beirut"),
@@ -2674,6 +2959,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant, 33.89821,35.47893",
         fileName = "countries - lb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "بيروت", "country" to "الجمهورية اللبنانية", "country_code" to "lb", "restaurant" to "Kushari Society", "road" to "شارع المهتما غاندي", "state" to "محافظة بيروت", "suburb" to "رأس بيروت"),
@@ -2685,6 +2971,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant, language=ar, 33.89821,35.47893",
         fileName = "countries - lb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tripoli", "country" to "Lebanon", "country_code" to "lb", "road" to "شارع عشير الدايه", "state" to "Qada Tarablos", "supermarket" to "SEVEN TO TWELVE"),
@@ -2696,6 +2983,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 34.43088,35.83017",
         fileName = "countries - lb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "First Caribbean International Bank", "country" to "Saint Lucia", "country_code" to "lc", "road" to "Bridge Street", "town" to "Castries"),
@@ -2707,6 +2995,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Castries, 14.01001,-60.99186",
         fileName = "countries - lc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Liechtenstein", "country_code" to "li", "county" to "Wahlkreis Oberland", "house_number" to "32", "museum" to "Kunstmuseum Liechtenstein", "pedestrian" to "Städtle", "postcode" to "9490", "village" to "Vaduz"),
@@ -2718,6 +3007,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Vaduz, 47.13947,9.52215",
         fileName = "countries - li",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "Colombo Lotus Tower", "city" to "Colombo", "country" to "Sri Lanka", "country_code" to "lk", "postcode" to "00200", "road" to "D. R. Wijewardene Mawatha", "state" to "Western Province", "state_district" to "Colombo District", "suburb" to "Suduwella"),
@@ -2730,6 +3020,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Landmark in Colombo, 6.9269,79.8584",
         fileName = "countries - lk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Monrovia", "country" to "Liberia", "country_code" to "lr", "county" to "Greater Monrovia", "neighbourhood" to "Vai Town", "postcode" to "1000", "public_building" to "Palm Hotel", "road" to "Broad Street", "state" to "Montserrado County", "suburb" to "Crown Hill"),
@@ -2741,6 +3032,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Monrovia, 6.31756,-10.80689",
         fileName = "countries - lr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Nedbank", "city" to "Maseru", "country" to "Lesotho", "country_code" to "ls", "postcode" to "100", "road" to "Kingsway", "state" to "Maseru", "suburb" to "Cathedral Area"),
@@ -2752,6 +3044,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Maseru: -29.31459, 27.48446",
         fileName = "countries - ls",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Vilnius", "country" to "Lithuania", "country_code" to "lt", "house_number" to "5", "postcode" to "02112", "road" to "Aduti\\u0161kio g.", "state" to "Vilnius County", "state_district" to "Vilniaus m. savivaldyb\\u0117", "suburb" to "Naujinink\\u0173 seni\\u016bnija"),
@@ -2762,6 +3055,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Vilnius street address - 54.66710,25.28669",
         fileName = "countries - lt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "Comed", "city" to "Luxembourg", "country" to "Luxemburg", "country_code" to "lu", "county" to "Canton Luxembourg", "house_number" to "13", "postcode" to "2016", "road" to "Route d'Esch", "suburb" to "Hollerich"),
@@ -2773,6 +3067,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Luxemburg, 49.60484,6.12045",
         fileName = "countries - lu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Riga", "country" to "Latvia", "country_code" to "lv", "county" to "Rīga", "house_number" to "81", "postcode" to "LV-1009", "road" to "Ģertrūdes iela", "state" to "Vidzeme", "suburb" to "Avoti"),
@@ -2783,6 +3078,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Riga street address - 56.95095,24.13474",
         fileName = "countries - lv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tripoli", "country" to "Libya", "country_code" to "ly", "hotel" to "Capital Hotel", "postcode" to "82510", "road" to "Arasafi", "state" to "Tripoli", "suburb" to "Old City المدينة القديمه"),
@@ -2794,6 +3090,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel, 32.88945,13.17402",
         fileName = "countries - ly",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "طرابلس", "country" to "ليبيا", "country_code" to "ly", "hotel" to "Capital Hotel", "postcode" to "82510", "road" to "Arasafi", "state" to "طرابلس", "suburb" to "Old City المدينة القديمه"),
@@ -2805,6 +3102,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel, language=ar 32.88945,13.17402",
         fileName = "countries - ly",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tripoli", "country" to "Libya", "country_code" to "ly", "postcode" to "82510", "road" to "Shara Muhammad Soukny", "state" to "Tripoli", "suburb" to "Bab Tajura", "supermarket" to "Suuq Nufleen"),
@@ -2816,6 +3114,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 32.88791,13.21650",
         fileName = "countries - ly",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Az zintan", "country" to "Libya", "country_code" to "ly", "road" to "طريق الصلوعة", "shop" to "محل مواد غدائية", "state" to "Jabal al Gharbi"),
@@ -2827,6 +3126,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Convenience store, 31.92505,12.24794",
         fileName = "countries - ly",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "الزنتان", "country" to "ليبيا", "country_code" to "ly", "road" to "طريق الصلوعة", "shop" to "محل مواد غدائية", "state" to "الجبل الغربي"),
@@ -2838,6 +3138,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Convenience store, language=ar, 31.92505,12.24794",
         fileName = "countries - ly",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Marrakesh", "city_district" to "Marrakech-Medina", "country" to "Morocco", "country_code" to "MA", "county" to "Province Marrakech", "neighbourhood" to "Quartier des tanneurs", "road" to "Rue El Adala", "state" to "Marrakech-Tensift-El Haouz", "suburb" to "Bab Doukkala", "townhall" to "Hotel de Ville"),
@@ -2849,6 +3150,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Jemaa el-Fnaa",
         fileName = "countries - ma",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Monaco", "country_code" to "mc", "hotel" to "Novotel", "house_number" to "16", "postcode" to "98000", "road" to "Boulevard Princesse Charlotte", "suburb" to "Monte-Carlo", "town" to "Monaco"),
@@ -2860,6 +3162,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Monaco, 43.73917,7.42224",
         fileName = "countries - mc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Chișinău", "country" to "Moldova", "country_code" to "MD", "county" to "Municipiul Chișinău", "house_number" to "121a", "museum" to "Muzeul de Istorie", "road" to "str. 31 August 1989", "postcode" to "MD-2012"),
@@ -2871,6 +3174,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "museum in Chișinău",
         fileName = "countries - md",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Montenegro", "country_code" to "me", "county" to "Opština Kotor", "hotel" to "Hotel Maria", "house_number" to "449", "pedestrian" to "Trg Sv. Luke", "postcode" to "85339", "suburb" to "Škaljari", "town" to "Kotor"),
@@ -2882,6 +3186,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Kotor, 42.42550,18.77045",
         fileName = "countries - me",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Saint-Martin", "country_code" to "mf", "post_office" to "Bureau de Poste", "postcode" to "97150", "road" to "Rue de La Poste", "state" to "Saint-Martin", "suburb" to "Concordia", "town" to "Marigot"),
@@ -2893,6 +3198,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post office in Marigot, 18.06671,-63.08566",
         fileName = "countries - mf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Ambassade de l'Inde", "city" to "Antananarivo", "country" to "Madagascar", "country_code" to "mg", "postcode" to "1", "road" to "Làlana Rajhonson Emile", "state" to "Province d'Antananarivo", "suburb" to "Tsaralalana"),
@@ -2905,6 +3211,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Antananarivo, -18.90744,47.52145",
         fileName = "countries - mg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Majuro", "country" to "Marshall Islands", "country_code" to "mh", "hotel" to "Marshall Islands Resort", "neighbourhood" to "Delap", "postcode" to "96060", "road" to "Lagoon Road"),
@@ -2916,6 +3223,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Majuro, 7.08646,171.37358",
         fileName = "countries - mh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Skopje", "country" to "F.Y.R.O.M.", "country_code" to "mk", "county" to "Municipality of Centar", "postcode" to "1000", "road" to "Мирче Ацев", "school" to "ОУ 11-ти Октомври", "state" to "Skopje Region", "suburb" to "Prolet"),
@@ -2927,6 +3235,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "School in Skopje, 41.9891,21.4406",
         fileName = "countries - mk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Ambassade de Russie", "city" to "Bamako", "country" to "Mali", "country_code" to "ml", "county" to "Bamako District", "postcode" to "E4373", "road" to "Rue 415", "state" to "Bamako District", "suburb" to "Niaréla"),
@@ -2938,6 +3247,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Bamako, 12.64230,-7.97833",
         fileName = "countries - ml",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Myanmar", "country_code" to "mm", "hotel" to "The Strand Hotel", "house_number" to "92", "postcode" to "11182", "road" to "ဆိပ်ကမ်းသာလမ်း - Seik Kan Tha St", "state" to "Yangon", "town" to "Kyauktada"),
@@ -2949,6 +3259,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hotel in Yangon, 16.76945,96.16260",
         fileName = "countries - mm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "TDB картын төв", "city" to "Ulaanbaatar", "country" to "Mongolia", "country_code" to "mn", "postcode" to "00976", "road" to "Seoul street", "state" to "Border Ulan Bator - Töv"),
@@ -2961,6 +3272,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Ulaanbaatar, 47.91484,106.91212",
         fileName = "countries - mn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "第四座欣濠軒 Torre 4", "country" to "Macau", "country_code" to "mo", "county" to "嘉模堂區 Nossa Senhora do Carmo", "house_number" to "641", "road" to "南京街 Rua de Nam Keng", "state" to "Macao", "state_district" to "Taipa", "suburb" to "Taipa", "village" to "Taipa Old Village"),
@@ -2972,6 +3284,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Macau, 22.16096,113.55467",
         fileName = "countries - mo",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Red Cross", "country" to "Northern Mariana Islands", "country_code" to "mp", "county" to "Saipan Municipality", "postcode" to "96950", "road" to "Chalan Tun Herman Pan", "state" to "Northern Mariana Islands", "town" to "Saipan"),
@@ -2983,6 +3296,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Red Cross office on Saipan, 15.12601,145.72340",
         fileName = "countries - mp",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Fort-de-France", "country" to "Martinique", "country_code" to "mq", "county" to "Fort-de-France", "courthouse" to "Tribunal Administratif de Fort-de-France", "postcode" to "97200", "road" to "Avenue Condorcet", "state" to "Martinique"),
@@ -2994,6 +3308,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Administrative building in Fort-au-France, 14.60443,-61.07770",
         fileName = "countries - mq",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nouakchott", "country" to "Mauritania", "country_code" to "mr", "hospital" to "CENTRE DE SANTE", "road" to "Route de la Résistance", "state" to "Nouakchott"),
@@ -3005,6 +3320,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Health centre, 18.1174,-15.9174",
         fileName = "countries - mr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "نواكشوط", "country" to "موريتانيا", "country_code" to "mr", "hospital" to "CENTRE DE SANTE", "road" to "Route de la Résistance", "state" to "نواكشوط"),
@@ -3016,6 +3332,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Health centre, language=ar, 18.1174,-15.9174",
         fileName = "countries - mr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nouakchott", "country" to "Mauritania", "country_code" to "mr", "place_of_worship" to "Mosquée du Qatar", "postcode" to "170", "road" to "Route Famille Dia", "state" to "Nouakchott"),
@@ -3027,6 +3344,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Mosque, 18.06802,-15.98678",
         fileName = "countries - mr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Mauritania", "country_code" to "mr", "hospital" to "Hôpital Régional de Nouadhibou", "road" to "N2", "state" to "Dakhlet Nouadhibou", "town" to "Nouadhibou"),
@@ -3038,6 +3356,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hospital, 20.9565,-17.0332",
         fileName = "countries - mr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Montserrat", "country_code" to "ms", "county" to "Saint Peter", "public_building" to "Government Headquarters", "road" to "Farer Plaza", "suburb" to "Gerald's", "town" to "Brades"),
@@ -3049,6 +3368,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Government building in Brades, 16.79305,-62.21082",
         fileName = "countries - ms",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Mellieha", "country" to "1002", "country_code" to "mt", "pharmacy" to "Karizia Pharmacy", "residential" to "mELLIEHA", "road" to "Triq \\u0120or\\u0121 Borg Olivier", "state" to "Malta", "suburb" to "I\\u010b-\\u010airkewwa"),
@@ -3060,6 +3380,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "pharmacy in Malta - 35.95777,14.36190",
         fileName = "countries - mt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "State Bank of Mauritius", "city" to "Port Louis", "country" to "Mauritius", "country_code" to "mu", "house_number" to "1", "neighbourhood" to "Caudan Waterfront", "road" to "Queen Elizabeth II Avenue", "state" to "Port Louis"),
@@ -3072,6 +3393,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Govt Building in Port Louis, -20.16189,57.50158",
         fileName = "countries - mu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Lallmatie", "country" to "Mauritius", "country_code" to "mu", "house_number" to "21", "neighbourhood" to "Mission Cross", "postcode" to "42602", "road" to "Old Trafford Road"),
@@ -3083,6 +3405,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "example address with postcode",
         fileName = "countries - mu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "Voice of Maledives", "city" to "Malé", "country" to "Maldives", "country_code" to "mv", "postcode" to "20237", "road" to "Buruzu Magu", "state" to "Malé"),
@@ -3094,6 +3417,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Radio station in Malé, 4.17244,73.50311",
         fileName = "countries - mv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Mpatsa House", "city" to "Lilongwe", "country" to "Malawi", "country_code" to "mw", "residential" to "Chilambula", "road" to "Paul Kagame Road", "state" to "Central"),
@@ -3105,6 +3429,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "building in Lilongwe, -13.97910,33.76927",
         fileName = "countries - mw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("pub" to "Wallace Whisky Bar", "house_number" to "45", "road" to "Avenida Tamaulipas", "city" to "Mexico City", "city_district" to "Cuauhtémoc", "country" to "Mexico", "country_code" to "MX", "state" to "Federal District", "postcode" to "06100"),
@@ -3117,6 +3442,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Mexico City",
         fileName = "countries - mx",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Malaysia", "country_code" to "my", "hamlet" to "Pudu", "museum" to "Telekom Museum", "postcode" to "50000", "road" to "Jalan Gereja", "state" to "Kuala Lumpur", "suburb" to "Kampung Baru"),
@@ -3130,6 +3456,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Kuala Lumpur, 3.14896,101.69916",
         fileName = "countries - my",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "Sturrock Shipping", "city" to "Cidade de Maputo", "city_district" to "Distrito Urbano de KaMpfumo", "country" to "Mozambique", "country_code" to "mz", "house_number" to "362", "postcode" to "1100", "road" to "Avenida Mao Tsé Tung", "state" to "Maputo", "suburb" to "Polana Cimento B"),
@@ -3141,6 +3468,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Maputo -25.96585,32.59418",
         fileName = "countries - mz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Swakopmund", "country" to "Namibia", "country_code" to "na", "hotel" to "Hotel Zum Kaiser", "house_number" to "4", "road" to "Sam Nujoma Avenue (Kaiser Wilhelm St)", "state" to "Erongo Region", "suburb" to "Central"),
@@ -3152,6 +3480,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Swakopmund, -22.67877,14.52302",
         fileName = "countries - na",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Immeuble Maréchal Foch", "city" to "Nouméa", "city_district" to "Secteur Ouest", "country" to "France, Nouvelle-Calédonie, Grande Terre et récifs d'Entrecasteaux (eaux territoriales)", "country_code" to "nc", "county" to "Province Sud", "postcode" to "98800", "road" to "Rue Jean Jaurès", "state" to "New Caledonia", "suburb" to "Centre-Ville"),
@@ -3163,6 +3492,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Nouméa, -22.27039,166.44270",
         fileName = "countries - nc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address" to "Embassy of the Federal Republic of Germany", "city" to "Niamey", "country" to "Niger", "country_code" to "ne", "house_number" to "71", "postcode" to "13416", "road" to "Boulevard Général De Gaulle", "state" to "Niamey", "suburb" to "Plateau", "village" to "Néini Goungou"),
@@ -3175,6 +3505,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Niamey, 13.52012,2.09463",
         fileName = "countries - ne",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Norfolk Island", "country_code" to "nf", "postcode" to "2899", "road" to "Mitchells Lane", "supermarket" to "P & R Groceries", "town" to "Burnt Pine"),
@@ -3186,6 +3517,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Shop in Burnt Pine, -29.03214,167.94704",
         fileName = "countries - nf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Maro Polo Hotel", "country" to "Nigeria", "country_code" to "ng", "county" to "Eti Osa", "road" to "Yeni Crescent", "state" to "Lagos", "village" to "Maiyegun"),
@@ -3198,6 +3530,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Lagos, -22.67877,14.52302",
         fileName = "countries - ng",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Managua", "city_district" to "District I", "country" to "Nicaragua", "country_code" to "ni", "county" to "Managua (Municipio)", "pedestrian" to "Plaza de la República", "postcode" to "11001", "public_building" to "Antiguo Palacio de Gobierno", "state" to "Managua", "suburb" to "Centro Histórico Cultural"),
@@ -3210,6 +3543,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post Office in Managua, 12.15550,-86.27209",
         fileName = "countries - ni",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Amsterdam", "city_district" to "Centrum", "country" to "The Netherlands", "country_code" to "nl", "county" to "MRA", "house_number" to "573", "postcode" to "1017CD", "road" to "Herengracht", "state" to "North Holland", "suburb" to "Amsterdam"),
@@ -3220,6 +3554,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Amsterdam, 52.36519,4.89683",
         fileName = "countries - nl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Amsterdam", "city_district" to "Centrum", "country" to "Koninkrijk der Nederlanden", "country_code" to "nl", "county" to "MRA", "house_number" to "573", "postcode" to "1017CD", "road" to "Herengracht", "state" to "North Holland", "suburb" to "Amsterdam"),
@@ -3230,6 +3565,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Amsterdam in Dutch, 52.36519,4.89683",
         fileName = "countries - nl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "The Netherlands", "country_code" to "nl", "house_number" to "14", "neighbourhood" to "Colon", "postcode" to "0000NA", "road" to "Jan Erasmusstraat", "state" to "Curaçao", "suburb" to "Seru Domi", "town" to "Willemstad"),
@@ -3240,6 +3576,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Willemstad, Curaçao 12.11148,-68.94561",
         fileName = "countries - nl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("name" to "Parliament of Aruba", "country" to "The Netherlands", "country_code" to "nl", "house_number" to "LSB 70", "road" to "L.G. Smith Boulevard", "state" to "Aruba", "town" to "Oranjestad"),
@@ -3251,6 +3588,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Parliament in Oranjestad, Aruba, 12.51781,-70.03646",
         fileName = "countries - nl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Oslo", "city_district" to "Gamle Oslo", "country" to "Norway", "country_code" to "no", "county" to "Oslo", "house_number" to "28", "neighbourhood" to "Arctanderbyen", "postcode" to "0650", "road" to "Åkebergveien", "state" to "Oslo", "suburb" to "Enerhaugen"),
@@ -3261,6 +3599,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house in Oslo",
         fileName = "countries - no",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Norge", "country_code" to "no", "county" to "Viken", "house_number" to "33", "neighbourhood" to "Belset", "postal_city" to "Rykkinn", "postcode" to "1349", "road" to "Grindstuveien", "suburb" to "Angerst", "village" to "Ringvoll"),
@@ -3271,6 +3610,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house in village with postal_city",
         fileName = "countries - no",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Kathmandu", "country" to "Nepal", "country_code" to "np", "county" to "Kathmandu", "mall" to "United World Trade Centre", "neighbourhood" to "Hyumat", "postcode" to "2243", "road" to "Tripureshwor Marg", "state" to "Central Development Region", "state_district" to "Bagmati", "suburb" to "Kuleshwor"),
@@ -3283,6 +3623,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "mall in Kathmandu, 27.69410,85.31334",
         fileName = "countries - np",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Nauru", "country_code" to "nr", "public_building" to "Parliament", "road" to "Island Ring Road", "village" to "Yaren"),
@@ -3294,6 +3635,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Parliment building in Yaren, -0.54741,166.91734",
         fileName = "countries - nr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Kiwibank", "country" to "Niue", "country_code" to "nu", "road" to "Tuila Road", "town" to "Alofi"),
@@ -3305,14 +3647,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Alofi, -19.05440,-169.92024",
         fileName = "countries - nu",
-      ),
-      TestCase(
-        components = mapOf("island" to "Null Island"),
-        expected = """
-        |Null Island
-        |""".trimMargin(),
-        description = "Null Island",
-        fileName = "other - null",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Wellington", "country" to "New Zealand", "country_code" to "nz", "county" to "Wellington City", "house_number" to "53", "postcode" to "6011", "road" to "Pirie Street", "state" to "Wellington", "suburb" to "Mount Victoria"),
@@ -3324,6 +3659,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "House in Wellington, -41.29789,174.78511",
         fileName = "countries - nz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Wellington", "country" to "New Zealand", "country_code" to "nz", "county" to "Wellington City", "state" to "Wellington"),
@@ -3333,6 +3669,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "City of Wellington",
         fileName = "countries - nz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Muscat, Oman", "country" to "Oman", "country_code" to "om", "postcode" to "116", "residential" to "Muscat", "road" to "Al Noor Street", "state" to "Muscat", "supermarket" to "Fathima Super Market"),
@@ -3346,6 +3683,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 23.6004,58.5395",
         fileName = "countries - om",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Muscat, Oman", "country" to "سلطنة عمان", "country_code" to "om", "postcode" to "116", "residential" to "Muscat", "road" to "Al Noor Street", "state" to "محافظة مسقط", "supermarket" to "Fathima Super Market"),
@@ -3359,6 +3697,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, language=ar, 23.6004,58.5395",
         fileName = "countries - om",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bakery" to "Muscat Bakery", "city" to "Muscat, Oman", "country" to "Oman", "country_code" to "om", "postcode" to "1727", "road" to "Street 3305", "state" to "Muscat", "suburb" to "Madinat al Sultan Qaboos"),
@@ -3372,6 +3711,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bakery, 23.59524,58.44763",
         fileName = "countries - om",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Salalah", "clinic" to "Al Zahir Medical Complex", "country" to "Oman", "country_code" to "om", "road" to "Al Nahdah Street", "state" to "Dhofar"),
@@ -3384,6 +3724,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Medical complex, 17.01483,54.09010",
         fileName = "countries - om",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Panamá", "country" to "Panamá", "country_code" to "pa", "guest_house" to "Panama House Bed & Breakfast", "road" to "Avenida 1 C Norte", "suburb" to "El Cangrejo"),
@@ -3396,6 +3737,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bed & Breakfast in Panama City, 8.99337,-79.52075",
         fileName = "countries - pa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Panama City", "country" to "Panama", "country_code" to "pa", "guest_house" to "Panama House Bed & Breakfast", "road" to "Avenida 1 C Norte", "suburb" to "El Cangrejo"),
@@ -3408,6 +3750,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "make sure no double Panama City",
         fileName = "countries - pa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Panama", "country_code" to "pa", "hamlet" to "Nueva California", "pharmacy" to "Celina", "road" to "Volcan-Rio Sereno", "state" to "Chiriquí"),
@@ -3420,6 +3763,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pharmacy in Nueva California, 8.77977,-82.64522",
         fileName = "countries - pa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("pub" to "Discoteca Ophera", "county" to "Huaural", "road" to "TUPAC AMARU", "town" to "Huacho", "country" to "Peru", "country_code" to "PE", "state" to "Lima"),
@@ -3431,6 +3775,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in San Juan",
         fileName = "countries - pe",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Mairie (bureaux administratifs)", "city" to "Papeete", "country" to "Polynésie française, Îles du Vent (eaux territoriales)", "country_code" to "pf", "county" to "Îles du Vent", "postcode" to "98714", "road" to "Rue des Remparts", "state" to "French Polynesia"),
@@ -3442,6 +3787,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Office in Papeete, -17.53714,-149.56608",
         fileName = "countries - pf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Port Moresby", "country" to "Papua New Guinea", "country_code" to "pg", "county" to "National Capital District", "hotel" to "Crowne Plaza Hotel", "road" to "Mary Street", "state" to "National Capital District", "suburb" to "Ela Beach"),
@@ -3453,6 +3799,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Port Moresby, -9.47861,147.15138",
         fileName = "countries - pg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "1140", "road" to "Alhambra", "city" to "Ermita", "postcode" to "1000", "county" to "Fifth District", "country" to "Philippines", "country_code" to "PH", "restaurant" to "Emerald Garden", "state" to "Metro Manila", "suburb" to "Ermita"),
@@ -3464,6 +3811,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "restaurant in Manila",
         fileName = "countries - ph",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("archipelago" to "Mindanao", "country" to "Philippines", "country_code" to "ph"),
@@ -3473,6 +3821,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "archipelago",
         fileName = "countries - ph",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "121", "road" to "Epifanio Delos Santos Ave.", "city" to "Mandaluyong", "postcode" to "1550", "suburb" to "Wack-wack Greenhills", "county" to "Fifth District", "country" to "Philippines", "country_code" to "PH", "attention" to "Mr. Juan Maliksi", "state" to "Metro Manila"),
@@ -3484,6 +3833,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "address",
         fileName = "countries - ph",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "121", "road" to "Epifanio Delos Santos Ave.", "city" to "Mandaluyong", "postcode" to "1550", "city_district" to "Wack-wack Greenhills", "county" to "Fifth District", "country" to "Philippines", "country_code" to "PH", "attention" to "Mr. Juan Maliksi", "state" to "Metro Manila"),
@@ -3495,6 +3845,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "address - city_district instead of suburb",
         fileName = "countries - ph",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Avari Beach Luxury Hotel", "city" to "Karachi", "country" to "Pakistan", "country_code" to "pk", "county" to "Karachi District", "postcode" to "75000", "road" to "Khan Road", "state" to "Sindh", "suburb" to "Lyari Town"),
@@ -3507,6 +3858,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Karachi, 24.84292,66.99589",
         fileName = "countries - pk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "1", "road" to "Adama Asnyka", "neighbourhood" to "Południe", "city" to "Bolesławiec", "postcode" to "59-700", "county" to "Bolesławiec", "state" to "Lower Silesian Voivodeship", "country" to "Poland", "country_code" to "PL"),
@@ -3517,6 +3869,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "road address at 51.262986,15.568984",
         fileName = "countries - pl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tarnów", "country" to "Poland", "country_code" to "pl", "county" to "Tarnów", "fuel" to "http://ump.waw.pl/ retrieved 11:18:52 11/17/09 (UMP-Tarnow/src/POI-paliwo.pnt-converted.txt)", "neighbourhood" to "XXVI Lecia", "postcode" to "33-106", "road" to "Mostowa", "state" to "Lesser Poland Voivodeship"),
@@ -3527,6 +3880,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "exclude garbage input, 50.01009,20.99881",
         fileName = "countries - pl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Szczecin", "city_district" to "Śródmieście", "country" to "Poland", "country_code" to "pl", "county" to "Szczecin", "house_number" to "19", "neighbourhood" to "Grabowo", "postcode" to "71637", "road" to "Teofila Firlika", "state" to "West Pomeranian Voivodeship", "suburb" to "Drzetowo-Grabowo"),
@@ -3537,6 +3891,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "ensure postcode well formatted, 53.43888,14.57544",
         fileName = "countries - pl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Société nouvelle des pêches de Miquelon", "city" to "Miquelon-Langlade", "country" to "Saint Pierre and Miquelon", "country_code" to "pm", "postcode" to "97500", "road" to "Rue Jacques Vigneau", "state" to "Saint Pierre and Miquelon"),
@@ -3548,6 +3903,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Miquelon, 47.10099,-56.37706",
         fileName = "countries - pm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Pitcairn Islands", "country_code" to "pn", "hospital" to "Pitcairn Health Centre", "residential" to "Adamstown", "road" to "Hill of Difficulty", "town" to "Adamstown"),
@@ -3558,6 +3914,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Health center in Adamstown, -25.06572,-130.10004",
         fileName = "countries - pn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bar" to "Wisos Velillas Bar", "house_number" to "252", "road" to "Calle San Francisco", "city" to "San Juan Antiguo", "country" to "Puerto Rico", "country_code" to "PR", "county" to "San Juan", "postcode" to "00901"),
@@ -3569,6 +3926,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in San Juan",
         fileName = "countries - pr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Palestine", "country_code" to "ps", "hostel" to "Hostel in Ramallah", "house_number" to "12", "postcode" to "700074", "road" to "Al-Nuzha Street", "state" to "Area A", "state_district" to "Ramallah and al-Bireh Governorate", "suburb" to "Ramallah Altahtah", "town" to "Ramallah"),
@@ -3580,6 +3938,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hostel, 31.90204,35.20281",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "فلسطين", "country_code" to "ps", "hostel" to "Hostel in Ramallah", "house_number" to "12", "postcode" to "700074", "road" to "شارع النزهة", "state" to "منطقة A", "state_district" to "محافظة رام الله والبيرة", "suburb" to "رام الله التحتة", "town" to "رام الله"),
@@ -3591,6 +3950,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hostel, language=ar, 31.90204,35.20281",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nablus", "country" to "Palestine", "country_code" to "ps", "doctors" to "Al Adham X-ray", "road" to "Sufian Street", "state" to "Area A", "state_district" to "Nablus Governorate", "suburb" to "Old City"),
@@ -3602,6 +3962,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Doctor's office, 32.22369,35.25941",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Nablus", "country" to "فلسطين", "country_code" to "ps", "doctors" to "الادهم للاشعه", "road" to "شارع سفيان", "state" to "منطقة A", "state_district" to "محافظة نابلس", "suburb" to "البلدة القديمة"),
@@ -3613,6 +3974,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Doctor's office, language=ar, 32.22369,35.25941",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Gaza", "country" to "Palestine", "country_code" to "ps", "doctors" to "Khorsheed Optician", "postcode" to "00972", "region" to "Gaza Strip", "road" to "Omar Al-Mukhtar St.", "state_district" to "Gaza Governorate", "suburb" to "Saknat az Zarqa"),
@@ -3624,6 +3986,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Optician, 31.50804,34.45912",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "غزة", "country" to "فلسطين", "country_code" to "ps", "doctors" to "خورشيد للبصريات", "postcode" to "00972", "region" to "‏قطاع غزّة‎", "road" to "شارع عمر المختار", "state_district" to "غزة", "suburb" to "ثكنة الزرقاء"),
@@ -3635,6 +3998,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Optician, language=ar, 31.50804,34.45912",
         fileName = "countries - ps",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Lisbon", "country" to "Portugal", "country_code" to "pt", "county" to "Lisboa", "house_number" to "11", "postcode" to "1500-203", "road" to "Avenida Conselheiro Barjona de Freitas", "suburb" to "Benfica"),
@@ -3645,6 +4009,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "38.74547,-9.18519",
         fileName = "countries - pt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Lisbon", "country" to "Portugal", "country_code" to "pt", "county" to "Lisbon", "house_number" to "2", "neighbourhood" to "São Vicente de Fora", "postcode" to "1170169", "road" to "Rua da Graça", "suburb" to "São Vicente"),
@@ -3655,6 +4020,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "38.72132,-9.13017",
         fileName = "countries - pt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("archipelago" to "Azores", "city" to "Ponta Delgada", "city_district" to "Rosto do Cão (Livramento)", "country" to "Portugal", "country_code" to "pt", "guest_house" to "Casa Do Populo", "house_number" to "1015", "neighbourhood" to "Livramento", "postcode" to "9500-614", "road" to "Rua Padre Domingos da Silva Costay", "state_district" to "São Miguel"),
@@ -3667,6 +4033,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "37.74851,-25.60450",
         fileName = "countries - pt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Palau", "country_code" to "pw", "courthouse" to "Palau Supreme Court", "road" to "Main Street", "town" to "Koror"),
@@ -3678,6 +4045,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Courthouse in Koror, 7.34122,134.47003",
         fileName = "countries - pw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bakery" to "Old Germany German Bakery", "city" to "Asuncion", "country" to "Paraguay", "country_code" to "py", "postcode" to "1409", "road" to "Milano", "state" to "Distrito Capital de Paraguay", "suburb" to "Tacumbú"),
@@ -3689,6 +4057,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "-25.2889244, -57.6466121",
         fileName = "countries - py",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "ahlibank Merqab Branch", "city" to "Doha", "country" to "Qatar", "country_code" to "qa", "postcode" to "22050", "road" to "Al Muthaf Street", "state" to "Doha", "suburb" to "(Sharg Zone) - Aslata (18)"),
@@ -3700,6 +4069,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank, 25.28695,51.54133",
         fileName = "countries - qa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Qatar", "country_code" to "qa", "postcode" to "41", "road" to "Main Al Thakira Street", "state" to "Al Khawr", "supermarket" to "Al Meera", "town" to "Al Thakira"),
@@ -3711,6 +4081,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Supermarket, 25.7144,51.5301",
         fileName = "countries - qa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Qatar", "country_code" to "qa", "pharmacy" to "Al Ayaan Pharmacy, Wakra", "road" to "Abdul Rahman Bin Jasim Street", "state" to "Al Wakrah", "town" to "Al Wakrah"),
@@ -3722,6 +4093,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pharmacy, 25.16318,51.59828",
         fileName = "countries - qa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Le Port", "country" to "France, La Réunion (eaux territoriales)", "country_code" to "re", "county" to "Saint-Paul", "house_number" to "17", "postcode" to "97420", "road" to "Rue François de Mahy", "state" to "Réunion"),
@@ -3732,6 +4104,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Le Port, -20.93750,55.29020",
         fileName = "countries - re",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Cluj-Napoca", "country" to "Romania", "country_code" to "ro", "county" to "Cluj-Napoca", "house_number" to "6", "postcode" to "400157", "road" to "Strada Ploiești", "state" to "Cluj", "suburb" to "Gruia"),
@@ -3742,6 +4115,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "building in Cluj - 46.77498,23.59376",
         fileName = "countries - ro",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("restaurant" to "Ресторан Лидо", "city" to "Belgrade", "country" to "Serbia", "country_code" to "RS", "neighbourhood" to "Donji Grad", "house_number" to "2", "postcode" to "11080", "road" to "Goce Delceva", "state" to "Central Serbia", "suburb" to "Zemun"),
@@ -3753,6 +4127,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "restaurant in Belgrade",
         fileName = "countries - rs",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cafe" to "Efes Istambul", "city" to "Сенной округ", "house_number" to "23", "postcode" to "190000", "road" to "Гороховая улица", "state" to "Санкт-Петербург", "state_district" to "Адмиралтейский район", "country" to "Российская Федерация", "country_code" to "ru"),
@@ -3766,6 +4141,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "cafe near 59.9313605,30.3175201",
         fileName = "countries - ru",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Батуринский сельсовет", "country" to "Россия", "country_code" to "ru", "county" to "Шадринский район", "hamlet" to "Камчатка", "state" to "Курганская область"),
@@ -3777,6 +4153,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village 55.8931701, 63.7019487",
         fileName = "countries - ru",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Малиновараккское сельское поселение", "country" to "Россия", "country_code" to "ru", "county" to "Лоухский район", "island" to "Ярославль", "state" to "Республика Карелия"),
@@ -3788,6 +4165,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "use island name",
         fileName = "countries - ru",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Energy Water and Sanitation Authority head office", "city" to "Kigali", "country" to "Rwanda", "country_code" to "rw", "county" to "Nyarugenge", "postcode" to "5011 Kigali-Rwanda", "road" to "KN 82 Street", "state" to "Kigali City", "suburb" to "Nyarugenge"),
@@ -3799,6 +4177,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Energy office in Kigali, -1.94421,30.05806",
         fileName = "countries - rw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("museum" to "National Museum of Saudi Arabia", "city" to "Riyadh", "country" to "Saudi Arabia", "country_code" to "sa", "postcode" to "12844", "road" to "شارع الوزير", "region" to "Riyadh Region"),
@@ -3810,6 +4189,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "museum in Saudi Arabia",
         fileName = "countries - sa",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Honiara", "country" to "Solomon Islands", "country_code" to "sb", "library" to "Solomon Islands National Library", "road" to "Mendana Avenue", "state" to "Capital Territory"),
@@ -3821,6 +4201,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Honiara, -9.43683,159.96441",
         fileName = "countries - sb",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Victoria", "country" to "Seychelles", "country_code" to "sc", "hotel" to "Bel Air Hotel", "island" to "Mahé", "postcode" to "SEZ", "road" to "Chemin Bel Air"),
@@ -3833,6 +4214,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel near Victoria, -4.62549,55.44879",
         fileName = "countries - sc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Khartoum Train Station", "city" to "Khartoum", "country" to "Sudan", "country_code" to "sd", "neighbourhood" to "Railway", "postcode" to "11114", "road" to "Al Imam Al Mahdi Road", "state" to "al-Khartum", "suburb" to "Downtown"),
@@ -3844,6 +4226,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Train station in Khartoum, 15.5953,32.5285",
         fileName = "countries - sd",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Gothenburg", "city_district" to "Centrum", "country" to "Sweden", "country_code" to "se", "county" to "Göteborgs och Bohus län", "hotel" to "Poseidon", "house_number" to "33", "postcode" to "41134", "road" to "Storgatan", "state" to "Västra Götalands län", "suburb" to "Vasastaden"),
@@ -3855,6 +4238,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Göteborg, 57.70012,11.96993",
         fileName = "countries - se",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cafe" to "Restaurang Thai House", "country" to "Sweden", "country_code" to "se", "county" to "Stockholms län", "house_number" to "7", "postcode" to "194 61", "road" to "Kanalvägen", "state" to "Stockholms län", "suburb" to "Infra City", "town" to "Upplands Väsby"),
@@ -3866,6 +4250,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Thai House",
         fileName = "countries - se",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Singapore", "country_code" to "SG", "house_number" to "76", "neighbourhood" to "Chinatown", "road" to "Shenton Way", "suburb" to "Shenton Way"),
@@ -3875,6 +4260,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "SG no postcode",
         fileName = "countries - sg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Singapore", "country_code" to "SG", "city" to "Singapore", "postcode" to "546080", "house_number" to "16", "road" to "Sandilands Road"),
@@ -3885,6 +4271,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Chinatown Singapore",
         fileName = "countries - sg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Singapore", "country_code" to "sg", "county" to "Southwest", "house_number" to "26", "postcode" to "130026", "residential" to "Dover Gardens", "road" to "Dover Crescent", "suburb" to "Queenstown"),
@@ -3895,6 +4282,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no city, 1.30585,103.78158",
         fileName = "countries - sg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Jurong East", "country" to "Singapore", "country_code" to "sg", "county" to "Southwest", "house_number" to "26", "postcode" to "130026", "residential" to "Dover Gardens", "road" to "Dover Crescent", "suburb" to "Queenstown"),
@@ -3905,6 +4293,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "wrong city, 1.30585,103.78158",
         fileName = "countries - sg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Saint Helena, Ascension and Tristan da Cunha", "country_code" to "sh", "public_building" to "Museum of St Helena", "road" to "Castle Terrace", "state" to "Saint Helena", "town" to "Jamestown"),
@@ -3917,6 +4306,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Museum in Jamestown, Saint Helena, -15.92498,-5.71862",
         fileName = "countries - sh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("community_centre" to "Prince Philip Hall", "country" to "Saint Helena, Ascension and Tristan da Cunha", "country_code" to "sh", "hamlet" to "Edinburgh of the Seven Seas", "postcode" to "TDCU 1ZZ", "state" to "Tristan da Cunha"),
@@ -3929,6 +4319,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building on Tristan de Cunha, -37.06714,-12.31022",
         fileName = "countries - sh",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Piran / Pirano", "country" to "Slovenia", "country_code" to "si", "house" to "Casino Riviera", "house_number" to "33", "postcode" to "6320", "road" to "Obala", "suburb" to "Liminjan / Limignano"),
@@ -3940,6 +4331,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hotel in Piran - 45.51410,13.58819",
         fileName = "countries - si",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Svalbard and Jan Mayen", "country_code" to "sj", "state" to "Jan Mayen"),
@@ -3949,6 +4341,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Airstrip on Jan Mayen, 70.9415,-8.6616",
         fileName = "countries - sj",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "District of Bratislava", "city_district" to "Bratislava - mestská časť Staré Mesto", "country" to "Slovakia", "country_code" to "sk", "county" to "Bratislava", "house_number" to "666/20", "postcode" to "811 03", "road" to "Panenská", "state" to "Region of Bratislava", "suburb" to "Staré Mesto"),
@@ -3959,6 +4352,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bratislava - 48.14776,17.10384",
         fileName = "countries - sk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Bratislava", "city_district" to "District of Bratislava I", "country" to "Slovakia", "country_code" to "sk", "house_number" to "12", "neighbourhood" to "Desiatky", "postcode" to "81105", "road" to "Železničiarska", "state" to "Region of Bratislava", "state_code" to "BL", "town" to "Old Town"),
@@ -3969,6 +4363,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bratislava town and city, fix postcode 48.15744,17.10839",
         fileName = "countries - sk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "St Thomas Primary School", "city" to "Freetown", "country" to "Sierra Leone", "country_code" to "sl", "neighbourhood" to "GRAYBUSH COM", "postcode" to "00232", "road" to "BISMARK JOHNSON ST", "state" to "Western Area", "state_district" to "Western Area Urban", "suburb" to "Kingtom"),
@@ -3980,6 +4375,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "School in Freetown, 8.48323,-13.24967",
         fileName = "countries - sl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "San Marino", "country_code" to "sm", "pedestrian" to "Contrada Santa Croce", "postcode" to "47893", "restaurant" to "Pier piz. rist.", "town" to "City of San Marino"),
@@ -3991,6 +4387,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Restaurant in City of San Marino, 43.93596,12.44716",
         fileName = "countries - sm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dakar", "country" to "Senegal", "country_code" to "sn", "hotel" to "Hotel ndjambour", "postcode" to "24951", "road" to "Rue Carnot", "state" to "Dakar", "suburb" to "Plateau"),
@@ -4002,6 +4399,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Dakar, 14.66731,-17.43996",
         fileName = "countries - sn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("commune" to "Commune de Yeumbeul Nord", "country" to "Senegal", "country_code" to "sn", "postcode" to "17000", "road" to "unnamed road", "state" to "Dakar Region", "state_district" to "Département de Keur Massar", "town" to "Arrondissement de Yeumbeul"),
@@ -4012,6 +4410,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "commune",
         fileName = "countries - sn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Urubu Hotel", "city" to "Mogadishu", "city_district" to "Xamar Weyne", "country" to "Somalia", "country_code" to "so", "county" to "Mogadishu", "road" to "Port Road", "state" to "Banadir", "suburb" to "Xamar Weyne"),
@@ -4024,6 +4423,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Mogadishu, 2.03459,45.34384",
         fileName = "countries - so",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Paramaribo", "country" to "Suriname", "country_code" to "sr", "county" to "Distrikt Paramaribo", "house_number" to "7", "postcode" to "597", "road" to "Simonsweg", "school" to "R.D. Simonsschool"),
@@ -4035,6 +4435,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "School in Paramaribo, 5.83041,-55.18020",
         fileName = "countries - sr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("address29" to "Diakonie Katastrophenhilfe", "city" to "Juba", "country" to "South Sudan", "country_code" to "ss", "road" to "Kokora Road", "state" to "Central Equatoria", "suburb" to "Governments Cantonment"),
@@ -4046,6 +4447,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Aid Organisation in Juba, 4.84927,31.59833",
         fileName = "countries - ss",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "São Tomé", "country" to "São Tomé and Príncipe", "country_code" to "st", "county" to "Agua Grande", "library" to "Biblioteca Nacional", "road" to "Avenida das Naçoes Unidas", "state" to "São Tomé Province", "suburb" to "Riboque"),
@@ -4057,6 +4459,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in São Tomé, 0.34004,6.73701",
         fileName = "countries - st",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Ministerio de Salud", "city" to "San Salvador", "country" to "El Salvador", "country_code" to "sv", "house_number" to "827", "neighbourhood" to "Centro Urbano IVU", "postcode" to "503", "road" to "Calle Arce", "state" to "Departamento de San Salvador", "suburb" to "Comunidad Tutunichapa"),
@@ -4069,6 +4472,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Government building in San Salvador, 13.69928,-89.19845",
         fileName = "countries - sv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Ministerio de Salud", "city" to "San Salvador", "country" to "El Salvador", "country_code" to "sv", "house_number" to "827", "neighbourhood" to "Centro Urbano IVU", "road" to "Calle Arce", "state" to "Departamento de San Salvador", "suburb" to "Comunidad Tutunichapa"),
@@ -4081,6 +4485,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "no floating dash if no postcode",
         fileName = "countries - sv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sint Maarten", "country" to "Sint Maarten", "country_code" to "sx", "hotel" to "La Vista Beach Resort", "neighbourhood" to "Pelican Key", "postcode" to "46226", "road" to "Billy Folly Road", "state" to "Sint Maarten (State of)", "suburb" to "Saint John's Estate"),
@@ -4091,6 +4496,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Resort in Sint Maarten, 18.02823,-63.09426",
         fileName = "countries - sx",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Damascus", "clinic" to "Plastic Surgery Clinic", "country" to "Syria", "country_code" to "sy", "neighbourhood" to "Baramkeh", "pedestrian" to "سوق الصالحية", "state" to "Rif Dimashq", "suburb" to "Kafar Sousseh"),
@@ -4103,6 +4509,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Plastic surgery clinic, 33.52042,36.29148",
         fileName = "countries - sy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "دمشق", "clinic" to "عيادة الجراحة التجميلية", "country" to "الجمهورية العربية السورية", "country_code" to "sy", "neighbourhood" to "البرامكة", "pedestrian" to "شارع جمال عبد الناصر", "state" to "ريف دمشق", "suburb" to "كفر سوسه"),
@@ -4115,6 +4522,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Plastic surgery clinic, language=ar, 33.52042,36.29148",
         fileName = "countries - sy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Damascus", "country" to "Syria", "country_code" to "sy", "pharmacy" to "Maooneh", "road" to "Albeirudi Street", "state" to "Rif Dimashq", "suburb" to "Soufanieh"),
@@ -4127,6 +4535,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pharmacy, 33.51929,36.31770",
         fileName = "countries - sy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "دمشق", "country" to "الجمهورية العربية السورية", "country_code" to "sy", "pharmacy" to "المعونة", "road" to "شارع البيرودي", "state" to "ريف دمشق", "suburb" to "Soufanieh"),
@@ -4139,6 +4548,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pharmacy, language=ar, 33.51929,36.31770",
         fileName = "countries - sy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Aleppo", "country" to "Syria", "country_code" to "sy", "neighbourhood" to "Al Jdeida", "pedestrian" to "Souq el Attarine", "place_of_worship" to "Al Bahramiyeh Mosque", "state" to "Aleppo", "suburb" to "حي باب النيرب"),
@@ -4151,6 +4561,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Mosque, 36.19821,37.15467",
         fileName = "countries - sy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Swaziland", "country_code" to "sz", "county" to "Inkhundla Manzini", "postcode" to "M100", "road" to "Kelly Street", "sports_centre" to "Manzini Club", "state" to "Sifundza seManzini", "town" to "Manzini"),
@@ -4163,6 +4574,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Manzini Club, -26.4943,31.3894",
         fileName = "countries - sz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Turks and Caicos Islands", "country_code" to "tc", "county" to "Provinciales and West Caicos", "neighbourhood" to "Five Cays", "road" to "Daffodil Close", "shop" to "Betty's market", "suburb" to "Millenium Hieghts", "town" to "Providenciales"),
@@ -4174,6 +4586,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Shop in Providenciales, 21.77988,-72.26589",
         fileName = "countries - tc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Turks and Caicos Islands", "country_code" to "tc", "island" to "Middle Caicos", "hamlet" to "Bambarra"),
@@ -4184,6 +4597,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hamlet on Middle Caicos",
         fileName = "countries - tc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "N'Djamena", "country" to "Chad", "country_code" to "td", "hotel" to "Le Meridien - Chari", "postcode" to "456", "road" to "Boulevard de Strasbourg", "state" to "N'Djamena Region"),
@@ -4195,6 +4609,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in N'Djamena, 12.11417,15.03121",
         fileName = "countries - td",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "France", "country_code" to "tf", "hospital" to "Hôpital", "road" to "Route de la Plage", "state" to "French Southern and Antarctic Lands", "village" to "Base Alfred Faure"),
@@ -4206,6 +4621,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Island in south Indian Ocean, -46.43266,51.85775",
         fileName = "countries - tf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Lomé", "country" to "Togo", "country_code" to "tg", "postcode" to "BP: 353", "public_building" to "Palais de Justice", "road" to "Aveenue de la Cooperation", "state" to "Maritime Region", "suburb" to "Hanoukopé"),
@@ -4217,6 +4633,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Govt building in Lomé, 6.12259,1.21944",
         fileName = "countries - tg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Thailand", "country_code" to "th", "neighbourhood" to "Wat Phraya Krai", "postcode" to "10120", "road" to "Thanon Charoen Krung", "school" to "Shrewsbury International School", "state" to "Bangkok", "suburb" to "Bang Kho Laem District"),
@@ -4229,6 +4646,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "School in Bangkok, 13.7101,100.5088",
         fileName = "countries - th",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dushanbe", "country" to "Tajikistan", "country_code" to "tj", "county" to "Rudaki District", "house_number" to "160", "postcode" to "734018", "road" to "Mushfiki Street", "state" to "Districts of Republican Subordination"),
@@ -4239,6 +4657,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "building in Душанбе, 38.55404,68.76598",
         fileName = "countries - tj",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Fakaofo", "country" to "Tokelau", "country_code" to "tk"),
@@ -4248,6 +4667,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village on Fakaofo, -9.3743,-171.2651",
         fileName = "countries - tk",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("embassy" to "Embaixada do Brasil", "country" to "East Timor", "country_code" to "tl", "hamlet" to "Palapasot", "postcode" to "10", "road" to "Rua César Maria de Serpa Rosa", "state" to "Dili"),
@@ -4259,6 +4679,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Dili, -8.54990,125.56677",
         fileName = "countries - tl",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Ashgabat", "country" to "Turkmenistan", "country_code" to "tm", "postcode" to "744000", "road" to "Kemine (2035) kocesi", "state" to "Ahal", "theatre" to "National Drama Theatre"),
@@ -4270,6 +4691,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Theatre in Ashgabat, 37.9432,58.3878",
         fileName = "countries - tm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Tunis", "country" to "Tunisia", "country_code" to "tn", "postcode" to "1000", "road" to "Rue de Grèce نهج اليونان", "state" to "Tunis", "state_district" to "Bab Bhar", "theatre" to "Théâtre Municipal de Tunis المسرح البلدي بتونس"),
@@ -4281,6 +4703,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "main theatre in Tunis 36.79900,10.18083",
         fileName = "countries - tn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("cinema" to "Cinéma Palace", "city" to "Sousse", "country" to "Tunisia", "country_code" to "tn", "postcode" to "4000", "road" to "Rue Pasteur", "state" to "Sousse", "suburb" to "Sousse Riadh"),
@@ -4292,6 +4715,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "cinema in Sousse 35.83053,10.64063",
         fileName = "countries - tn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "صفاقس", "country" to "Tunisia", "country_code" to "tn", "county" to "Sfax Medina", "hospital" to "CNSS", "postcode" to "3000", "road" to "RN 1 طو", "state" to "Sfax", "suburb" to "صفاقس الجديدة"),
@@ -4303,6 +4727,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hospital in Sfax 34.7411,10.7590",
         fileName = "countries - tn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "National Reserve Bank of Tonga", "country" to "Tonga", "country_code" to "to", "neighbourhood" to "Fongoloa", "road" to "Hala Sālote", "state" to "Vahe Kolofo'ou", "suburb" to "Kolofo'ou", "town" to "Ma'ufanga"),
@@ -4314,6 +4739,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Ma'ufanga, -21.13647,-175.19540",
         fileName = "countries - to",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Turkey", "country_code" to "tr", "county" to "Beşiktaş", "house" to "Swissotel Bosphorus", "house_number" to "2", "postcode" to "34357", "road" to "Bayıldım Caddesi", "state" to "Istanbul", "suburb" to "Vişnezade", "town" to "Beşiktaş"),
@@ -4325,6 +4751,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hotel in Istanbul",
         fileName = "countries - tr",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "23", "road" to "O'Connor Street", "neighbourhood" to "Ellerslie Park", "city" to "Port of Spain", "suburb" to "Woodbrook", "postcode" to "190130", "restaurant" to "More Vino Limited", "country" to "Trinidad and Tobago", "country_code" to "TT"),
@@ -4337,6 +4764,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "cafe in Port of Spain",
         fileName = "countries - tt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Funafuti", "country" to "Tuvalu", "country_code" to "tv", "public_building" to "Philatelic Office", "road" to "Vaiaku Road"),
@@ -4348,6 +4776,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "office in Funafuti, -8.52706,179.19302",
         fileName = "countries - tv",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "新北市板橋區", "country" to "中華民國", "country_code" to "tw", "house_number" to "168", "library" to "新北市立圖書館板橋四維分館", "postcode" to "220", "road" to "陽明街", "state" to "台中台北各種語言名稱", "suburb" to "新北板橋土城多語言"),
@@ -4359,6 +4788,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in 新北市板橋區, 25.02511,121.46330",
         fileName = "countries - tw",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Dar es Salaam", "city_district" to "Buguruni", "country" to "Tanzania", "country_code" to "tz", "hotel" to "CWE Hotel", "postcode" to "78570", "road" to "Mivinjeni Street", "state" to "Dar es Salaam", "suburb" to "Mivinjeni"),
@@ -4370,6 +4800,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "CWE Hotel in Dar es Salaam -6.83009,39.24981",
         fileName = "countries - tz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Songea", "country" to "Tanzania", "country_code" to "tz", "hospital" to "Ruvuma Regional Hospital", "road" to "Sokoine Road", "state" to "Ruvuma", "state_district" to "Songea"),
@@ -4382,6 +4813,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Ruvuma Regional Hospital -10.68053,35.65144",
         fileName = "countries - tz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Tanzania", "country_code" to "tz", "road" to "T14", "state" to "Manyara", "state_district" to "Babati"),
@@ -4393,6 +4825,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "-4.22466,35.72255",
         fileName = "countries - tz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Tanzania", "country_code" to "tz", "state" to "Manyara", "state_district" to "Babati"),
@@ -4403,6 +4836,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "-4.29340,35.30726",
         fileName = "countries - tz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Kyiv", "suburb" to "Solomianskyi district", "country" to "Ukraine", "country_code" to "UA", "house_number" to "2д", "bar" to "Утка Bar", "postcode" to "03038", "road" to "Protasiv Yar Street"),
@@ -4416,6 +4850,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Kiev",
         fileName = "countries - ua",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Orient Plaza", "city" to "Kampala", "country" to "Uganda", "country_code" to "ug", "county" to "Kampala", "house_number" to "6/6A", "neighbourhood" to "Nakivubo", "postcode" to "7063", "road" to "Kampala Road", "state" to "Central Region", "suburb" to "Kibuli"),
@@ -4427,6 +4862,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Kampala, 0.31220, 32.58532",
         fileName = "countries - ug",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Uganda", "country_code" to "ug", "state" to "Arua", "subcounty" to "Ayivuni"),
@@ -4437,6 +4873,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "subcounty",
         fileName = "countries - ug",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States Minor Outlying Islands", "country_code" to "um", "island" to "Wake Island"),
@@ -4446,6 +4883,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Wake Island, 19.29337,166.64899",
         fileName = "countries - um",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "301", "road" to "Hamilton Avenue", "neighbourhood" to "Crescent Park", "city" to "Palo Alto", "postcode" to "94303", "county" to "Santa Clara County", "state" to "California", "country" to "United States of America", "country_code" to "US"),
@@ -4456,6 +4894,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house number in California",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "301", "road" to "Hamilton Avenue", "neighbourhood" to "Crescent Park", "city" to "Palo Alto", "postcode" to "94303", "county" to "Santa Clara County", "state" to "California", "country" to "USA", "country_code" to "US"),
@@ -4466,6 +4905,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "correct \"USA\"",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "301", "road" to "Hamilton Avenue", "neighbourhood" to "Crescent Park", "city" to "Palo Alto", "postcode" to "94303", "county" to "Santa Clara County", "state" to "California", "country" to "United States", "country_code" to "US"),
@@ -4476,6 +4916,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "correct \"United States\"",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "301", "road" to "Hamilton Avenue", "neighbourhood" to "Crescent Park", "city" to "Palo Alto", "postcode" to "94303", "county" to "Santa Clara County", "state" to "California", "country" to "US", "country_code" to "US"),
@@ -4486,6 +4927,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "correct \"US\"",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Palo Alto", "country" to "United States of America", "country_code" to "US", "county" to "Santa Clara County", "state" to "California"),
@@ -4495,6 +4937,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "town in CA",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "New York", "country" to "United States of America", "country_code" to "US", "state" to "New York"),
@@ -4504,6 +4947,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "NY, NY",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "175", "road" to "Varick Street", "neighbourhood" to "Greenwich Village", "postcode" to "10014", "county" to "New York County", "state_district" to "New York City", "state" to "New York", "country" to "United States of America", "country_code" to "US"),
@@ -4514,6 +4958,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "house number in New York, no city",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "postcode" to "20500", "state" to "Washington, D.C."),
@@ -4523,6 +4968,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "state code for Washington, D.C.",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "postcode" to "20500", "state" to "Washington DC"),
@@ -4532,6 +4978,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "state code for Washington DC",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "USA", "country_code" to "us", "county" to "Volusia County", "house_number" to "928", "postcode" to "32132", "road" to "Flagler Avenue", "state" to "Florida", "state_code" to "FL", "suburb" to "Edgewater"),
@@ -4542,6 +4989,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "use suburb if no city",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States", "country_code" to "us", "county" to "Nassau County", "house_number" to "4", "municipality" to "Town of Oyster Bay", "postcode" to "11803", "road" to "Lakeville Lane", "state" to "New York", "state_code" to "NY"),
@@ -4552,6 +5000,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "clean up \"Town of \" 40.7805,-73.4875",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "USA", "country_code" to "us", "county" to "Volusia County", "house_number" to "928", "postcode" to "32132", "road" to "Flagler Avenue", "state" to "Florida", "state_code" to "FL"),
@@ -4562,6 +5011,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "use county if no city",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Washington", "country" to "United States of America", "country_code" to "us", "postcode" to "20500", "state" to "District of Columbia"),
@@ -4571,6 +5021,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "state code for Washington DC",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "county" to "St. Thomas Island", "library" to "Enid M Baa Library and Archives", "postcode" to "00803", "road" to "Dronningens Gade", "state" to "United States Virgin Islands", "town" to "Charlotte Amalie"),
@@ -4582,6 +5033,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Charlotte Amalie, 18.34119,-64.93546",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "state" to "New York", "state_district" to "New York"),
@@ -4591,6 +5043,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "state_district",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "state" to "New York"),
@@ -4600,6 +5053,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "just state",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "county" to "Saginaw County", "municipality" to "Taymouth Township", "state" to "Michigan", "village" to "Burt"),
@@ -4610,6 +5064,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "municipality",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "us", "county" to "Costilla County", "postcode" to "08113", "state" to "Colorado", "village" to "Fort Garland"),
@@ -4620,6 +5075,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "village",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Homestead", "country" to "United States of America", "country_code" to "us", "county" to "Miami-Dade County", "hamlet" to "Homestead Trailer Park", "postcode" to "33030", "state" to "Florida"),
@@ -4630,6 +5086,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "hamlet",
         fileName = "countries - us",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Maldonado", "country" to "Uruguay", "country_code" to "uy", "neighbourhood" to "Barrio Centro", "postcode" to "20000", "restaurant" to "Classic Restaurant y Parrillada", "road" to "Román Guerra", "state" to "Maldonado", "suburb" to "Sarubbi"),
@@ -4641,6 +5098,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "-34.90338,-54.95706",
         fileName = "countries - uy",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Samarkand", "country" to "Uzbekistan", "country_code" to "uz", "postcode" to "140100", "pub" to "BLUES Cafe", "house_number" to "66", "road" to "Amir Temur street", "state" to "Samarkand Province"),
@@ -4654,6 +5112,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Samarkand",
         fileName = "countries - uz",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Gallinaro Tower", "country" to "Vatican City", "country_code" to "va", "postcode" to "00120", "road" to "Viale San Benedetto"),
@@ -4665,6 +5124,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Vatican City, 41.90586,12.45105",
         fileName = "countries - va",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Vatican City", "country_code" to "va", "postcode" to "00120", "road" to "Press Way", "supermarket" to "Vatican Supermarket", "town" to "Vatican City"),
@@ -4676,6 +5136,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "supermarket in Vatican City, 41.9046,12.4566",
         fileName = "countries - va",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Bank of St Vincent and the Grenadines", "city" to "Kingstown", "country" to "Saint Vincent and the Grenadines", "country_code" to "vc", "county" to "Saint George", "road" to "Grenville Street"),
@@ -4687,6 +5148,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Bank in Kingstown, 13.15545,-61.22592",
         fileName = "countries - vc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("house_number" to "33", "road" to "Av. Teresa de La Parra", "city" to "Parroquia San Pedro", "county" to "Municipio Libertador", "neighbourhood" to "Los Chaguaramos", "country" to "Venezuela", "country_code" to "VE", "postcode" to "1040", "restaurant" to "El Carretón", "state_district" to "Caracas", "state" to "Capital District"),
@@ -4698,6 +5160,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "restaurant in Caracas",
         fileName = "countries - ve",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Government of the BVI", "country" to "British Virgin Islands", "country_code" to "vg", "house_number" to "33", "island" to "Tortola", "postcode" to "VG1110", "road" to "Admin Drive", "town" to "Road Town"),
@@ -4709,6 +5172,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Govt building in Road Town, 18.42132,-64.61601",
         fileName = "countries - vg",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "United States of America", "country_code" to "vi", "county" to "St. Thomas Island", "library" to "Enid M Baa Library and Archives", "postcode" to "00803", "road" to "Dronningens Gade", "state" to "United States Virgin Islands", "town" to "Charlotte Amalie"),
@@ -4720,6 +5184,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Library in Charlotte Amalie, 18.34119,-64.93546",
         fileName = "countries - vi",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("road" to "Tran Quang Khai", "city" to "Nha Trang", "country" to "Vietnam", "country_code" to "VN", "postcode" to "48058", "bar" to "Why Not Bar", "suburb" to "Tan Lap District", "state" to "Khanh Hoa province"),
@@ -4733,6 +5198,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "bar in Nha Trang",
         fileName = "countries - vn",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Port Vila", "country" to "Vanuatu", "country_code" to "vu", "guest_house" to "Room with a view", "road" to "Rue de Paris Street", "state" to "Shefa Province"),
@@ -4744,6 +5210,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Hotel in Port Vila, -17.73112,168.31218",
         fileName = "countries - vu",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Palais royal d'Uvéa", "country" to "France, Wallis-et-Futuna (eaux territoriales)", "country_code" to "wf", "road" to "RT1", "state" to "Wallis and Futuna", "town" to "Mata'utu"),
@@ -4755,6 +5222,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Building in Mata'utu",
         fileName = "countries - wf",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Āpia", "country" to "Samoa", "country_code" to "ws", "post_office" to "Samoa Post Office", "road" to "Beach Road", "suburb" to "Tuanaimato"),
@@ -4766,6 +5234,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "post office in Āpia, -13.83128,-171.76770",
         fileName = "countries - ws",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("country" to "Sovereign Base Areas of Akrotiri and Dhekelia", "country_code" to "xc", "county" to "Dhekelia", "road" to "unnamed road", "village" to "Dasaki Achnas"),
@@ -4777,6 +5246,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "35.0257,33.7803",
         fileName = "countries - xc",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Pristina", "continent" to "Europe", "country" to "Kosovo", "country_code" to "xk", "district" to "District of Prishtina", "house_number" to "13", "municipality" to "Municipality of Pristina", "postcode" to "10010", "road" to "Ahmet Haxhiu", "suburb" to "Medresa"),
@@ -4787,26 +5257,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Address in Pristina, 42.66925,21.16407",
         fileName = "countries - xk",
-      ),
-      TestCase(
-        components = mapOf("city" to "City", "country" to "Null Island", "country_code" to "XX", "county" to "County", "house_number" to "123", "postcode" to "PCPCPC", "road" to "Main Street", "state" to "State", "suburb" to "The Hood"),
-        expected = """
-        |Main Street 123
-        |PCPCPC City
-        |Null Island
-        |""".trimMargin(),
-        description = "generic format",
-        fileName = "other - xx",
-      ),
-      TestCase(
-        components = mapOf("city" to "City", "country" to "Null Island", "country_code" to "XX", "state" to "State"),
-        expected = """
-        |City
-        |State
-        |Null Island
-        |""".trimMargin(),
-        description = "generic fallback",
-        fileName = "other - xx",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Sanʿaʾ", "country" to "Yemen", "country_code" to "ye", "county" to "Qada Sana", "mall" to "Yassin Spices", "road" to "شارع الحربي"),
@@ -4818,6 +5269,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Shop, 15.28562,44.23028",
         fileName = "countries - ye",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "صنعاء", "country" to "اليمن", "country_code" to "ye", "county" to "قضاء صنعاء", "mall" to "بهارات ياسين", "road" to "شارع الحربي"),
@@ -4829,6 +5281,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Shop, language=ar, 15.28562,44.23028",
         fileName = "countries - ye",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("bank" to "Centeral Bank of Yemen", "city" to "Sanʿaʾ", "country" to "Yemen", "country_code" to "ye", "county" to "Qada Sana", "postcode" to "01", "road" to "Al Zubayri Street"),
@@ -4840,6 +5293,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Central bank, 15.34924,44.20724",
         fileName = "countries - ye",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Aden", "country" to "Yemen", "country_code" to "ye", "county" to "Aden Directorate", "fast_food" to "Pizza", "residential" to "كريتر", "road" to "خط صيرة", "state" to "‘Adan Governorate"),
@@ -4851,6 +5305,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Pizzaria, 12.77954,45.04418",
         fileName = "countries - ye",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Conseil Général de Mayotte", "country" to "France, Mayotte (eaux territoriales)", "country_code" to "yt", "postcode" to "97600", "road" to "Rue Houmadi Bacar", "state" to "Mayotte", "town" to "Mamoudzou"),
@@ -4862,6 +5317,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Government building in Mamoudzou, -12.77958,45.23145",
         fileName = "countries - yt",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Cape Town", "city_district" to "Cape Town Subcouncil 15", "country" to "RSA", "country_code" to "za", "county" to "City of Cape Town", "house_number" to "3", "postcode" to "7700", "road" to "Upper Alma Road", "state" to "Western Cape", "suburb" to "Rosebank"),
@@ -4874,6 +5330,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Cape Town street address -33.95345,18.47252",
         fileName = "countries - za",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("city" to "Lusaka", "country" to "Zambia", "country_code" to "zm", "post_office" to "Central Post Office", "postcode" to "34681", "road" to "Church Road", "state" to "Lusaka Province", "suburb" to "Luneta"),
@@ -4885,6 +5342,7 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Post Office in Lusaka, -15.41667,28.28225",
         fileName = "countries - zm",
+        abbreviate = false,
       ),
       TestCase(
         components = mapOf("building" to "Russian Embassy", "city" to "Harare", "country" to "Zimbabwe", "country_code" to "zw", "postcode" to "00263", "road" to "Colquhoun Street", "state" to "Harare Province", "suburb" to "Avondale West"),
@@ -4896,5 +5354,37 @@ public val testCases: List<TestCase> = listOf(
         |""".trimMargin(),
         description = "Embassy in Harare, -17.82107,31.04553",
         fileName = "countries - zw",
+        abbreviate = false,
+      ),
+      TestCase(
+        components = mapOf("island" to "Null Island"),
+        expected = """
+        |Null Island
+        |""".trimMargin(),
+        description = "Null Island",
+        fileName = "other - null",
+        abbreviate = false,
+      ),
+      TestCase(
+        components = mapOf("city" to "City", "country" to "Null Island", "country_code" to "XX", "county" to "County", "house_number" to "123", "postcode" to "PCPCPC", "road" to "Main Street", "state" to "State", "suburb" to "The Hood"),
+        expected = """
+        |Main Street 123
+        |PCPCPC City
+        |Null Island
+        |""".trimMargin(),
+        description = "generic format",
+        fileName = "other - xx",
+        abbreviate = false,
+      ),
+      TestCase(
+        components = mapOf("city" to "City", "country" to "Null Island", "country_code" to "XX", "state" to "State"),
+        expected = """
+        |City
+        |State
+        |Null Island
+        |""".trimMargin(),
+        description = "generic fallback",
+        fileName = "other - xx",
+        abbreviate = false,
       ),
     )


### PR DESCRIPTION
* add `abbreviate` option to test cases
* fix `AddressFormatter` to not replace abbreviations, if the component has a special character prefix

Aligned mostly with [Perl implementation](https://metacpan.org/dist/Geo-Address-Formatter/source/lib/Geo/Address/Formatter.pm#L756)