### PR TITLE
SESA-3647: Create template module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: macos-14
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish on GitHub Packages
+name: Publish to Maven Central
 on:
   push:
     tags:
@@ -6,12 +6,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: macos-14
     timeout-minutes: 20
 
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repo
@@ -27,7 +26,7 @@ jobs:
         id: variables
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
-      - name: Publish on GitHub Packages
+      - name: Publish to Maven central
         run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_signReleaseEnabled: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ buildscript {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 plugins {
     alias(libs.plugins.dokka) apply false
 }

--- a/template/build.gradle.kts
+++ b/template/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+* Copyright 2022 GLS eCom Lab GmbH
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+plugins {
+    kotlin("multiplatform")
+}
+
+repositories {
+    mavenCentral()
+}
+
+kotlin {
+    jvm()
+    jvmToolchain(11)
+
+    iosArm64()
+    iosSimulatorArm64()
+}

--- a/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplate.kt
+++ b/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplate.kt
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
-include(":library")
-include(":template")
-include(":YamlConverter")
+package com.bettermile.addressformatter.template
+
+/**
+ * Represents the logic to render address from one specific template.
+ *
+ * Use [AddressTemplateDefinition] annotation to create an instance of [AddressTemplate].
+ */
+@SubclassOptInRequired(InternalForInheritanceAddressFormatterApi::class)
+interface AddressTemplate {
+
+    /**
+     * Render an address based on the address components from [context]. Uses only some specific components.
+     *
+     * @param context [Map] of address component names and values for the address to render
+     */
+    fun render(context: Map<String, String>): String
+}

--- a/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplateDefinition.kt
+++ b/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplateDefinition.kt
@@ -34,6 +34,22 @@ package com.bettermile.addressformatter.template
  * {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}}
  * ```
  *
+ * Example usage:
+ *
+ * ```kotlin
+ * package com.example.addresses
+ *
+ * @AddressTemplateDefinition("""{{{attention}}}
+ * {{{house}}}
+ * {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}} {{{house_number}}}
+ * {{{postcode}}} {{#first}} {{{postal_city}}} || {{{town}}} || {{{city}}} || {{{village}}} || {{{municipality}}} || {{{hamlet}}} || {{{county}}} || {{{state}}} {{/first}}
+ * {{{archipelago}}}
+ * {{{country}}}""")
+ * val customTemplate = AddressTemplates.customTemplate
+ * ```
+ *
+ * The `AddressTemplates` object will be in the same package as the definition
+ *
  * @param value address template used to render addresses
  * @param propertyName name of the property to hold the information. Defaults to the name of the target property.
  */

--- a/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplateDefinition.kt
+++ b/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/AddressTemplateDefinition.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 GLS eCom Lab GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bettermile.addressformatter.template
+
+/**
+ *
+ * Generates an [AddressTemplate] in a `AddressFormatters` object with the given [propertyName]. The address template
+ * contains of literal text, placeholders for address components and an option to choose the first not empty component.
+ * It's a subset of [mustache specification](https://mustache.github.io/).
+ *
+ * Placeholders are surrounded by 3 curly braces
+ * ```
+ * {{{road}}}
+ * ```
+ *
+ * If there are multiple components which could fit at one place, you can use the `first` lambda. It splits the text
+ * between `{{#first}}` and `{{/first}}` at `||`, replaces the placeholders with the components and checks for the first
+ * element, that's not blank or uses an empty string, if all elements are blank.
+ * ```
+ * {{#first}} {{{road}}} || {{{place}}} || {{{hamlet}}} {{/first}}
+ * ```
+ *
+ * @param value address template used to render addresses
+ * @param propertyName name of the property to hold the information. Defaults to the name of the target property.
+ */
+@Repeatable
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+annotation class AddressTemplateDefinition(val value: String, val propertyName: String = "")

--- a/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/InternalForInheritanceAddressFormatterApi.kt
+++ b/template/src/commonMain/kotlin/com/bettermile/addressformatter/template/InternalForInheritanceAddressFormatterApi.kt
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
-include(":library")
-include(":template")
-include(":YamlConverter")
+package com.bettermile.addressformatter.template
+
+@Target(AnnotationTarget.CLASS)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is a com.bettermile.addressformatter API that is not intended to be inherited from. " +
+            "Use the AddressTemplateDefinition annotation to generate an address template based on an " +
+            "address template String.",
+)
+annotation class InternalForInheritanceAddressFormatterApi


### PR DESCRIPTION
- run jobs on macos runners, so the multiplatform projects can build
- rename outdated workflow name
- add maven repository to root project, because the multiplatform plugin needs this
- add new template module
- document created interfaces and annotations