### PR TITLE
NO-JIRA: Align string creation in #first lambda

### DIFF
--- a/template-processor/src/test/kotlin/com/bettermile/addressformatter/template/processor/internal/AddressFormattersRendererTest.kt
+++ b/template-processor/src/test/kotlin/com/bettermile/addressformatter/template/processor/internal/AddressFormattersRendererTest.kt
@@ -103,8 +103,12 @@ class AddressFormattersRendererTest {
         )
         val expected = """
             return buildString {
-              sequence {
-                yield(${MULTI_LINE_STRING_INDICATOR}text$MULTI_LINE_STRING_INDICATOR)
+              sequence<String> {
+                yield(
+                  buildString {
+                    append("text")
+                  }
+                )
               }
               .firstOrNull(String::isNotBlank)?.also(::append)
             }
@@ -123,8 +127,12 @@ class AddressFormattersRendererTest {
         )
         val expected = """
             return buildString {
-              sequence {
-                yield($MULTI_LINE_STRING_INDICATOR${'$'}{context["text"] ?: ""}$MULTI_LINE_STRING_INDICATOR)
+              sequence<String> {
+                yield(
+                  buildString {
+                    context["text"]?.also(::append)
+                  }
+                )
               }
               .firstOrNull(String::isNotBlank)?.also(::append)
             }
@@ -151,8 +159,14 @@ class AddressFormattersRendererTest {
         )
         val expected = """
             return buildString {
-              sequence {
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["text"] ?: ""} $MULTI_LINE_STRING_INDICATOR)
+              sequence<String> {
+                yield(
+                  buildString {
+                    append(' ')
+                    context["text"]?.also(::append)
+                    append(' ')
+                  }
+                )
               }
               .firstOrNull(String::isNotBlank)?.also(::append)
             }
@@ -188,10 +202,27 @@ class AddressFormattersRendererTest {
         )
         val expected = """
             return buildString {
-              sequence {
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["text"] ?: ""} $MULTI_LINE_STRING_INDICATOR)
-                yield($MULTI_LINE_STRING_INDICATOR${'$'}{context["component"] ?: ""}, ${'$'}{context["element"] ?: ""}$MULTI_LINE_STRING_INDICATOR)
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["street"] ?: ""}$MULTI_LINE_STRING_INDICATOR)
+              sequence<String> {
+                yield(
+                  buildString {
+                    append(' ')
+                    context["text"]?.also(::append)
+                    append(' ')
+                  }
+                )
+                yield(
+                  buildString {
+                    context["component"]?.also(::append)
+                    append(", ")
+                    context["element"]?.also(::append)
+                  }
+                )
+                yield(
+                  buildString {
+                    append(' ')
+                    context["street"]?.also(::append)
+                  }
+                )
               }
               .firstOrNull(String::isNotBlank)?.also(::append)
             }
@@ -240,10 +271,28 @@ class AddressFormattersRendererTest {
               append('\n')
               context["house"]?.also(::append)
               append('\n')
-              sequence {
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["road"] ?: ""} $MULTI_LINE_STRING_INDICATOR)
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["place"] ?: ""} $MULTI_LINE_STRING_INDICATOR)
-                yield($MULTI_LINE_STRING_INDICATOR ${'$'}{context["hamlet"] ?: ""} $MULTI_LINE_STRING_INDICATOR)
+              sequence<String> {
+                yield(
+                  buildString {
+                    append(' ')
+                    context["road"]?.also(::append)
+                    append(' ')
+                  }
+                )
+                yield(
+                  buildString {
+                    append(' ')
+                    context["place"]?.also(::append)
+                    append(' ')
+                  }
+                )
+                yield(
+                  buildString {
+                    append(' ')
+                    context["hamlet"]?.also(::append)
+                    append(' ')
+                  }
+                )
               }
               .firstOrNull(String::isNotBlank)?.also(::append)
               append(' ')
@@ -259,5 +308,3 @@ class AddressFormattersRendererTest {
         assertEquals(expected, actual)
     }
 }
-
-private const val MULTI_LINE_STRING_INDICATOR = "\"\"\""

--- a/template-processor/src/test/resources/testcases/lambda_placeholder/success/AddressTemplates.kt
+++ b/template-processor/src/test/resources/testcases/lambda_placeholder/success/AddressTemplates.kt
@@ -8,9 +8,21 @@ internal object AddressTemplates {
   public val test: AddressTemplate
     get() = object : AddressTemplate {
       override fun render(context: Map<String, String>): String = buildString {
-        sequence {
-          yield(""" ${context["content1"] ?: ""} """)
-          yield(""" ${context["content2"] ?: ""} """)
+        sequence<String> {
+          yield(
+            buildString {
+              append(' ')
+              context["content1"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["content2"]?.also(::append)
+              append(' ')
+            }
+          )
         }
         .firstOrNull(String::isNotBlank)?.also(::append)
       }

--- a/template-processor/src/test/resources/testcases/multiline/success/AddressTemplates.kt
+++ b/template-processor/src/test/resources/testcases/multiline/success/AddressTemplates.kt
@@ -12,10 +12,28 @@ internal object AddressTemplates {
         append('\n')
         context["house"]?.also(::append)
         append('\n')
-        sequence {
-          yield(""" ${context["road"] ?: ""} """)
-          yield(""" ${context["place"] ?: ""} """)
-          yield(""" ${context["hamlet"] ?: ""} """)
+        sequence<String> {
+          yield(
+            buildString {
+              append(' ')
+              context["road"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["place"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["hamlet"]?.also(::append)
+              append(' ')
+            }
+          )
         }
         .firstOrNull(String::isNotBlank)?.also(::append)
         append(' ')
@@ -23,15 +41,63 @@ internal object AddressTemplates {
         append('\n')
         context["postcode"]?.also(::append)
         append(' ')
-        sequence {
-          yield(""" ${context["postal_city"] ?: ""} """)
-          yield(""" ${context["town"] ?: ""} """)
-          yield(""" ${context["city"] ?: ""} """)
-          yield(""" ${context["village"] ?: ""} """)
-          yield(""" ${context["municipality"] ?: ""} """)
-          yield(""" ${context["hamlet"] ?: ""} """)
-          yield(""" ${context["county"] ?: ""} """)
-          yield(""" ${context["state"] ?: ""} """)
+        sequence<String> {
+          yield(
+            buildString {
+              append(' ')
+              context["postal_city"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["town"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["city"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["village"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["municipality"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["hamlet"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["county"]?.also(::append)
+              append(' ')
+            }
+          )
+          yield(
+            buildString {
+              append(' ')
+              context["state"]?.also(::append)
+              append(' ')
+            }
+          )
         }
         .firstOrNull(String::isNotBlank)?.also(::append)
         append('\n')


### PR DESCRIPTION
Use same logic to create String inside `#first` lambda block as in rest of the template. This should increase the maintainability.